### PR TITLE
feat: Docker 雙前端架構 — Vue build 模式 + Next.js /demo 路由

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,16 +47,15 @@ services:
     container_name: teaching-platform-frontend-builder
     build:
       context: ./frontend
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
       args:
         VITE_API_URL: ${VITE_API_URL:-http://localhost:8001}
     depends_on:
       backend:
         condition: service_started
     volumes:
-      - ./frontend/src:/app/src
-      - ./frontend/public:/app/public
-    restart: unless-stopped
+      - frontend-dist:/dist
+    restart: "no"
 
   frontend-demo:
     container_name: teaching-platform-frontend-demo
@@ -64,10 +63,15 @@ services:
       context: ./frontend-dennis
       dockerfile: Dockerfile
       args:
-        VITE_API_URL: ${VITE_API_URL:-http://localhost:8001}
-    volumes:
-      - frontend-dist:/dist
-    restart: "no"
+        NEXT_PUBLIC_API_URL: ${API_URL:-http://localhost:8001}
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - ${FRONTEND_PORT:-4173}:3000
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped
 
   nginx:
     container_name: teaching-platform-nginx
@@ -75,31 +79,33 @@ services:
     depends_on:
       frontend:
         condition: service_completed_successfully
+      backend:
+        condition: service_started
     volumes:
       - frontend-dist:/usr/share/nginx/html:ro
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
-      - ${FRONTEND_PORT:-4173}:80
-    restart: unless-stopped
-
-  studio:
-    container_name: supabase-studio
-    image: supabase/studio:2025.12.17-sha-43f4f7f
-    restart: unless-stopped
-
-  nginx:
-    container_name: teaching-platform-nginx
-    image: nginx:alpine
-    depends_on:
-      frontend:
-        condition: service_started
-      backend:
-        condition: service_started
-    volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
-    ports:
       - 80:80
     restart: unless-stopped
+
+  # studio:
+  #   container_name: supabase-studio
+  #   image: supabase/studio:2025.12.17-sha-43f4f7f
+  #   restart: unless-stopped
+
+  # nginx:
+  #   container_name: teaching-platform-nginx
+  #   image: nginx:alpine
+  #   depends_on:
+  #     frontend:
+  #       condition: service_started
+  #     backend:
+  #       condition: service_started
+  #   volumes:
+  #     - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+  #   ports:
+  #     - 80:80
+  #   restart: unless-stopped
 
   db:
     container_name: teaching-platform-db
@@ -137,31 +143,32 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     restart: "no"
 
-  pgadmin:
-    container_name: teaching-platform-pgadmin
-    image: dpage/pgadmin4:9.12.0
-    depends_on:
-      db:
-        condition: service_healthy
-    environment:
-      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@local.dev}
-      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
-      PGADMIN_CONFIG_SERVER_MODE: "True"
-      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "True"
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    volumes:
-      - ./pgadmin/servers.json:/pgadmin4/servers.json:ro
-      - pgadmin-data:/var/lib/pgadmin
-    entrypoint: >
-      /bin/sh -c "
-      echo \"db:5432:*:postgres:$$POSTGRES_PASSWORD\" > /tmp/pgpass &&
-      chmod 600 /tmp/pgpass &&
-      /entrypoint.sh
-      "
-    ports:
-      - ${PGADMIN_PORT:-5050}:80
+  # pgadmin:
+  #   container_name: teaching-platform-pgadmin
+  #   image: dpage/pgadmin4:9.12.0
+  #   depends_on:
+  #     db:
+  #       condition: service_healthy
+  #   environment:
+  #     PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@local.dev}
+  #     PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
+  #     PGADMIN_CONFIG_SERVER_MODE: "True"
+  #     PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "True"
+  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+  #   volumes:
+  #     - ./pgadmin/servers.json:/pgadmin4/servers.json:ro
+  #     - pgadmin-data:/var/lib/pgadmin
+  #   entrypoint: >
+  #     /bin/sh -c "
+  #     echo \"db:5432:*:postgres:$$POSTGRES_PASSWORD\" > /tmp/pgpass &&
+  #     chmod 600 /tmp/pgpass &&
+  #     /entrypoint.sh
+  #     "
+  #   ports:
+  #     - ${PGADMIN_PORT:-5050}:80
 
 volumes:
   db-data:
   redis-data:
   frontend-dist:
+  pgadmin-data:

--- a/frontend-dennis/next.config.js
+++ b/frontend-dennis/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
+    basePath: '/demo',
 
     typescript: {
         ignoreBuildErrors: true,

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,4 +26,4 @@ RUN npm run build
 
 # Copy built assets to the shared volume at /dist
 # rm -rf ensures a clean copy on every rebuild
-CMD ["sh", "-c", "rm -rf /dist/* && cp -r /app/dist/* /dist/"]
+CMD ["sh", "-c", "mkdir -p /dist && rm -rf /dist/* && cp -r /app/dist/* /dist/"]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -2,6 +2,10 @@ server {
     listen       80;
     server_name  localhost;
 
+    # Serve Vue frontend static files from volume
+    root /usr/share/nginx/html;
+    index index.html;
+
     # Proxy API requests to backend
     location /api/ {
         proxy_pass http://backend:8000/api/;
@@ -12,32 +16,21 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Proxy to Vite dev server
-    location / {
-        proxy_pass http://frontend:5173;
+    # Proxy /demo to Next.js frontend-demo (Next.js basePath: '/demo')
+    location /demo {
+        proxy_pass http://frontend-demo:3000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # Vite HMR WebSocket
-    location /ws {
-        proxy_pass http://frontend:5173;
-        proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
     }
 
-    # Vite HMR via @vite/client
-    location /@vite/ {
-        proxy_pass http://frontend:5173;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
+    # SPA fallback: all other routes return index.html
+    location / {
+        try_files $uri $uri/ /index.html;
     }
 
     # Handle server errors

--- a/scripts/ngrok.sh
+++ b/scripts/ngrok.sh
@@ -6,7 +6,7 @@
 #   ./scripts/ngrok.sh status  - Show current tunnel URL
 #   ./scripts/ngrok.sh url     - Print tunnel URL only
 
-PORT=8001
+PORT=80
 
 case "$1" in
   start)


### PR DESCRIPTION
- frontend (Vue) 改用 production Dockerfile，build 完輸出到 frontend-dist volume
- nginx port 80 統一入口：靜態檔 serve Vue、/demo proxy 到 Next.js、/api proxy 到 backend
- next.config.js 加上 basePath: '/demo' 支援子路徑部署
- frontend/Dockerfile CMD 加 mkdir -p /dist 修復 volume 目錄不存在問題
- 註解掉 pgadmin、studio