### PR TITLE
fix: 員工權限即時生效 + E2E 測試修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,24 @@ docker compose down -v         # Stop and remove volumes
 ```
 
 ### IMPORTANT: Backend 修改後測試流程
-修改 backend 程式碼後，必須重新 build 並啟動才能測試：
+修改 backend 程式碼後，必須重新 build 並啟動，然後跑 E2E 測試確認沒有 regression：
 ```bash
-docker compose up --build backend -d   # 重新 build 並啟動 backend
-# 或
-docker compose down && docker compose up --build -d  # 完整重建所有服務
+# 1. 重新 build 並啟動 backend
+docker compose up --build backend -d
+
+# 2. 跑 E2E 測試（必須在 backend 啟動後執行）
+cd backend
+python -m pytest tests/e2e/ -v
+
+# 單獨跑某個 E2E 測試
+python -m pytest tests/e2e/live_e2e_booking_flow_test.py -v
+python -m pytest tests/e2e/live_e2e_contracts_test.py -v
+python -m pytest tests/e2e/live_e2e_courses_test.py -v
+python -m pytest tests/e2e/live_e2e_leave_flow_test.py -v
+python -m pytest tests/e2e/live_e2e_student_flow_test.py -v
+python -m pytest tests/e2e/live_e2e_teacher_flow_test.py -v
 ```
+**後端每次修改都必須跑過 E2E 測試才能 commit。**
 
 ### Frontend 修改注意
 前端修改只能在 `frontend-dennis/` 目錄下進行，絕對不可以動到 `frontend/` 目錄。

--- a/backend/app/api/v1/employees.py
+++ b/backend/app/api/v1/employees.py
@@ -237,6 +237,7 @@ async def update_employee(
                 raise HTTPException(status_code=500, detail="更新員工失敗")
 
         # 同步 user_profiles 角色（僅限已有帳號的員工）
+        profile = None
         try:
             profile = await supabase_service.table_select(
                 table="user_profiles", select="id,role_id",
@@ -256,8 +257,6 @@ async def update_employee(
                         sync_data["role_id"] = str(role_row["id"])
                 if data.employee_type:
                     sync_data["employee_subtype"] = data.employee_type
-            elif requested_role_id:
-                raise HTTPException(status_code=400, detail="此員工尚未建立帳號，無法設定角色")
                 if sync_data:
                     await supabase_service.table_update(
                         table="user_profiles",
@@ -265,8 +264,22 @@ async def update_employee(
                         filters={"id": profile[0]["id"]},
                     )
                     logger.info(f"Employee {employee_id}: user_profiles 同步 {sync_data}")
+            elif requested_role_id:
+                raise HTTPException(status_code=400, detail="此員工尚未建立帳號，無法設定角色")
         except Exception as sync_err:
             logger.warning(f"Employee {employee_id}: 同步角色失敗: {sync_err}")
+
+        # 清除 Redis 權限快取，讓更改立即生效（不需重新登入）
+        if profile:
+            try:
+                from app.services.redis_service import redis_service
+                uid = profile[0]['id']
+                await redis_service.delete(f"permission_level:{uid}")
+                await redis_service.delete(f"role_id:{uid}")
+                await redis_service.delete(f"employee_type:{uid}")
+                await redis_service.delete(f"page_perm:{uid}")
+            except Exception:
+                pass
 
         enriched = await enrich_employee(result)
         return DataResponse(message="員工更新成功", data=EmployeeResponse(**enriched))

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -155,17 +155,22 @@ async def get_current_user(request: Request) -> CurrentUser:
         teacher_id = identity["teacher_id"]
         employee_id = identity["employee_id"]
 
-    # 如果 token 中沒有權限資訊，從服務查詢
-    if permission_level == 0 and employee_id is not None:
+    # 員工每次都從 Redis/DB 取最新權限（避免改角色後要重新登入）
+    role = payload.get("role", "student")
+    role_id = payload.get("role_id")
+    if employee_id is not None:
         permission_level = await permission_service.get_user_permission_level(user_id)
+        fresh_role_id = await permission_service.get_user_role_id(user_id)
+        if fresh_role_id:
+            role_id = fresh_role_id
         if not employee_type:
             employee_type = await permission_service.get_user_employee_type(user_id)
 
     return CurrentUser(
         user_id=user_id,
         email=payload.get("email", ""),
-        role=payload.get("role", "student"),
-        role_id=payload.get("role_id"),
+        role=role,
+        role_id=role_id,
         session_id=session_id,
         session_data=session_data,
         employee_type=employee_type,

--- a/backend/app/services/permission_service.py
+++ b/backend/app/services/permission_service.py
@@ -121,6 +121,25 @@ class PermissionService:
         except Exception:
             return None
 
+    async def get_user_role_id(self, user_id: str) -> Optional[str]:
+        """取得用戶目前的 role_id（從 Redis 快取或 DB）"""
+        cache_key = f"role_id:{user_id}"
+        cached = await redis_service.get(cache_key)
+        if cached is not None:
+            return cached if cached != "null" else None
+
+        try:
+            result = await supabase_service.table_select(
+                table="user_profiles",
+                select="role_id",
+                filters={"id": f"eq.{user_id}"},
+            )
+            role_id = str(result[0]["role_id"]) if result and result[0].get("role_id") else None
+            await redis_service.set(cache_key, role_id or "null", expire_seconds=self.CACHE_TTL)
+            return role_id
+        except Exception:
+            return None
+
     async def check_permission(
         self,
         user_id: str,

--- a/backend/tests/e2e/live_e2e_teacher_flow_test.py
+++ b/backend/tests/e2e/live_e2e_teacher_flow_test.py
@@ -270,8 +270,8 @@ class TeacherFlowTester:
 
     async def _get_avatar_upload_url(self):
         resp = await self._post(
-            f"/api/v1/teachers/{self.teacher_id}/avatar/upload-url?file_ext=png",
-            json={},
+            f"/api/v1/teachers/{self.teacher_id}/avatar/upload-url",
+            json={"file_name": "test_avatar.png"},
         )
         if resp.status_code != 200: return f"{resp.status_code} {resp.text[:200]}"
         data = resp.json()


### PR DESCRIPTION
- 員工 permission_level / role_id 改為每次從 Redis/DB 取值，不信任 JWT
- 更新員工角色時自動清除所有權限快取（permission_level/role_id/employee_type/page_perm）
- 修正 employees.py sync_data table_update 死碼 bug（原本寫在 raise 之後）
- permission_service 新增 get_user_role_id 方法（含 Redis 快取）
- E2E teacher 頭像測試配合 API 簽名更新（file_ext → file_name）
- CLAUDE.md 加入後端 E2E 測試必跑規範