### PR TITLE
refactor: 統一錯誤碼與 response 格式

### DIFF
--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -812,7 +812,7 @@ async def get_my_student_info(
         user_student_id = current_user.student_id
 
         if not user_student_id:
-            return {"data": None}
+            return {"success": True, "message": "操作成功", "data": None}
 
         student = await supabase_service.table_select(
             table="students",
@@ -821,9 +821,9 @@ async def get_my_student_info(
         )
 
         if not student:
-            return {"data": None}
+            return {"success": True, "message": "操作成功", "data": None}
 
-        return {"data": student[0]}
+        return {"success": True, "message": "操作成功", "data": student[0]}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -837,7 +837,7 @@ async def get_my_contracts(
         user_student_id = current_user.student_id
 
         if not user_student_id:
-            return {"data": []}
+            return {"success": True, "message": "操作成功", "data": []}
 
         contracts = await supabase_service.table_select(
             table="student_contracts",
@@ -880,7 +880,7 @@ async def get_my_contracts(
             contract["course_name"] = ", ".join(course_names) if course_names else None
             enriched.append(contract)
 
-        return {"data": enriched}
+        return {"success": True, "message": "操作成功", "data": enriched}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -2371,7 +2371,7 @@ async def get_student_options(
             select="id,student_no,name,student_type",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": students}
+        return {"success": True, "message": "操作成功", "data": students}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -2402,7 +2402,7 @@ async def get_teacher_options(
                 filters=filters,
             )
 
-        return {"data": teachers}
+        return {"success": True, "message": "操作成功", "data": teachers}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -2457,7 +2457,7 @@ async def get_overlapping_course_options(
                     teacher_course_ids.add(d["course_id"])
 
         if not teacher_course_ids:
-            return {"data": []}
+            return {"success": True, "message": "操作成功", "data": []}
 
         # 3. 決定最終課程 IDs
         if is_trial:
@@ -2478,7 +2478,7 @@ async def get_overlapping_course_options(
             final_course_ids = teacher_course_ids & student_course_ids
 
         if not final_course_ids:
-            return {"data": []}
+            return {"success": True, "message": "操作成功", "data": []}
 
         # 4. 查課程資料
         courses = await supabase_service.table_select(
@@ -2490,7 +2490,7 @@ async def get_overlapping_course_options(
         # 過濾交集課程
         result = [c for c in courses if c["id"] in final_course_ids]
 
-        return {"data": result}
+        return {"success": True, "message": "操作成功", "data": result}
     except HTTPException:
         raise
     except Exception as e:
@@ -2508,7 +2508,7 @@ async def get_course_options(
             select="id,course_code,course_name",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": courses}
+        return {"success": True, "message": "操作成功", "data": courses}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -2561,7 +2561,7 @@ async def get_student_contract_options(
             contract["course_name"] = ", ".join(course_names) if course_names else None
             enriched.append(contract)
 
-        return {"data": enriched}
+        return {"success": True, "message": "操作成功", "data": enriched}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -2717,7 +2717,7 @@ async def get_substitute_teacher_options(
 
         # 排序：is_preferred=True 排前面
         result.sort(key=lambda x: (not x["is_preferred"], x.get("teacher_no", "")))
-        return {"data": result}
+        return {"success": True, "message": "操作成功", "data": result}
 
     except HTTPException:
         raise
@@ -2741,7 +2741,7 @@ async def get_teacher_contract_options(
                 "contract_status": "eq.active"
             },
         )
-        return {"data": contracts}
+        return {"success": True, "message": "操作成功", "data": contracts}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -2774,7 +2774,7 @@ async def get_teacher_slot_options(
         if date_to:
             slots = [s for s in slots if s.get("slot_date") <= date_to.isoformat()]
 
-        return {"data": slots}
+        return {"success": True, "message": "操作成功", "data": slots}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -1972,13 +1972,13 @@ async def batch_create_bookings(
             if not has_course_rate:
                 raise HTTPException(status_code=400, detail="教師無此課程的授課資格")
 
-        # 驗證教師等級是否符合學生偏好（主要教師不受等級限制）
-        await preference_service.validate_teacher_level_for_course(
-            student_id=data.student_id,
-            teacher_id=data.teacher_id,
-            course_id=course_id,
-            teacher_level=teacher[0].get("teacher_level", 1),
-        )
+        # 驗證教師是否在學生偏好白名單內
+        allowed_set, _ = await preference_service.get_student_allowed_teachers(data.student_id)
+        if data.teacher_id not in allowed_set:
+            raise HTTPException(
+                status_code=400,
+                detail="此教師不在學生的偏好可預約教師範圍內，請先設定教師偏好"
+            )
 
         # 驗證教師合約存在（如果有提供）
         teacher_contract_id = data.teacher_contract_id

--- a/backend/app/api/v1/employees.py
+++ b/backend/app/api/v1/employees.py
@@ -51,7 +51,7 @@ async def list_roles_for_employees(
         rows = await supabase_service.pool.fetch(
             "SELECT id, key, name FROM roles ORDER BY key"
         )
-        return {"data": [{"id": str(r["id"]), "key": r["key"], "name": r["name"]} for r in rows]}
+        return {"success": True, "message": "操作成功", "data": [{"id": str(r["id"]), "key": r["key"], "name": r["name"]} for r in rows]}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"取得角色列表失敗: {str(e)}")
 

--- a/backend/app/api/v1/health.py
+++ b/backend/app/api/v1/health.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 router = APIRouter(prefix="/health", tags=["健康檢查"])
 
-@router.get("/", response_model=dict)
+@router.get("", response_model=dict)
 async def health_check():
     """基本健康檢查"""
     return {

--- a/backend/app/api/v1/student_contracts.py
+++ b/backend/app/api/v1/student_contracts.py
@@ -171,7 +171,7 @@ async def get_student_options(
             select="id,student_no,name",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": students}
+        return {"success": True, "message": "操作成功", "data": students}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -198,7 +198,7 @@ async def get_course_options(
                 },
             )
             if not enrollments:
-                return {"data": []}
+                return {"success": True, "message": "操作成功", "data": []}
 
             course_ids = [e["course_id"] for e in enrollments]
 
@@ -213,14 +213,14 @@ async def get_course_options(
             )
             courses = [{"id": str(r["id"]), "course_code": r["course_code"], "course_name": r["course_name"]} for r in rows]
 
-            return {"data": courses}
+            return {"success": True, "message": "操作成功", "data": courses}
         else:
             courses = await supabase_service.table_select(
                 table="courses",
                 select="id,course_code,course_name",
                 filters={"is_deleted": "eq.false", "is_active": "eq.true"},
             )
-            return {"data": courses}
+            return {"success": True, "message": "操作成功", "data": courses}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -236,7 +236,7 @@ async def get_teacher_options(
             select="id,teacher_no,name",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": teachers}
+        return {"success": True, "message": "操作成功", "data": teachers}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -771,7 +771,7 @@ async def list_contract_details(
                 d["course_name"] = course[0]["course_name"] if course else None
             enriched.append(d)
 
-        return {"data": [StudentContractDetailResponse(**d) for d in enriched]}
+        return {"success": True, "message": "操作成功", "data": [StudentContractDetailResponse(**d) for d in enriched]}
 
     except HTTPException:
         raise
@@ -1058,7 +1058,7 @@ async def list_leave_records(
             },
         )
 
-        return {"data": [StudentContractLeaveRecordResponse(**r) for r in records]}
+        return {"success": True, "message": "操作成功", "data": [StudentContractLeaveRecordResponse(**r) for r in records]}
 
     except HTTPException:
         raise

--- a/backend/app/api/v1/student_courses.py
+++ b/backend/app/api/v1/student_courses.py
@@ -51,7 +51,7 @@ async def get_student_options(
             select="id,student_no,name",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": students}
+        return {"success": True, "message": "操作成功", "data": students}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -67,7 +67,7 @@ async def get_course_options(
             select="id,course_code,course_name",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": courses}
+        return {"success": True, "message": "操作成功", "data": courses}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -196,7 +196,7 @@ async def get_courses_by_student(
                 e["course_name"] = c["course_name"] if c else None
                 e["student_name"] = None  # 已知是同一學生，不需要查
 
-        return {"data": enrollments}
+        return {"success": True, "message": "操作成功", "data": enrollments}
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"取得學生選課失敗: {str(e)}")

--- a/backend/app/api/v1/student_teacher_preferences.py
+++ b/backend/app/api/v1/student_teacher_preferences.py
@@ -352,6 +352,20 @@ async def update_preference(
         if not update_data:
             raise HTTPException(status_code=400, detail="沒有需要更新的欄位")
 
+        # 重複檢查：防止更新後與同學生的其他偏好重複
+        current = existing[0]
+        new_teacher_id = update_data.get("primary_teacher_id", current.get("primary_teacher_id"))
+        if new_teacher_id:
+            # 教師模式：檢查同學生是否已有相同教師的偏好
+            dup = await supabase_service.pool.fetch(
+                "SELECT id FROM student_teacher_preferences "
+                "WHERE student_id = $1 AND primary_teacher_id = $2 "
+                "AND is_deleted = false AND id != $3",
+                current["student_id"], new_teacher_id, preference_id,
+            )
+            if dup:
+                raise HTTPException(status_code=400, detail="此學生已有該教師的偏好設定，無法重複指定")
+
         if employee_id:
             update_data["updated_by"] = employee_id
 

--- a/backend/app/api/v1/student_teacher_preferences.py
+++ b/backend/app/api/v1/student_teacher_preferences.py
@@ -58,7 +58,7 @@ async def get_teacher_options(
             select="id,teacher_no,name,teacher_level",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"success": True, "data": teachers}
+        return {"success": True, "message": "操作成功", "data": teachers}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -77,11 +77,11 @@ async def get_course_options(
             filters={"student_id": student_id, "is_deleted": "eq.false"},
         )
         if not student_courses:
-            return {"success": True, "data": []}
+            return {"success": True, "message": "操作成功", "data": []}
 
         course_ids = [sc["course_id"] for sc in student_courses if sc.get("course_id")]
         if not course_ids:
-            return {"success": True, "data": []}
+            return {"success": True, "message": "操作成功", "data": []}
 
         # 查詢課程詳情
         pool = supabase_service.pool
@@ -89,7 +89,7 @@ async def get_course_options(
             "SELECT id, course_name FROM courses WHERE id = ANY($1) AND is_deleted = FALSE",
             course_ids,
         )
-        return {"success": True, "data": [dict(c) for c in courses]}
+        return {"success": True, "message": "操作成功", "data": [dict(c) for c in courses]}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -104,7 +104,7 @@ async def get_allowed_teachers(
         allowed_set, has_preferences = await preference_service.get_student_allowed_teachers(student_id)
 
         if not has_preferences:
-            return {"success": True, "data": []}
+            return {"success": True, "message": "操作成功", "data": []}
 
         # 查詢白名單內的教師完整資料
         teachers = await supabase_service.table_select(
@@ -114,7 +114,7 @@ async def get_allowed_teachers(
         )
         filtered = [t for t in teachers if str(t["id"]) in allowed_set]
 
-        return {"success": True, "data": filtered}
+        return {"success": True, "message": "操作成功", "data": filtered}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -159,7 +159,7 @@ async def list_preferences(
                 p["course_name"] = c_map.get(str(p.get("course_id")))
                 p["primary_teacher_name"] = t_map.get(str(p.get("primary_teacher_id")))
 
-        return {"success": True, "data": prefs}
+        return {"success": True, "message": "操作成功", "data": prefs}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/app/api/v1/student_teacher_preferences.py
+++ b/backend/app/api/v1/student_teacher_preferences.py
@@ -119,7 +119,7 @@ async def get_allowed_teachers(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/", tags=["學生教師偏好"])
+@router.get("", tags=["學生教師偏好"])
 async def list_preferences(
     student_id: str = Query(..., description="學生 ID"),
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))
@@ -164,7 +164,7 @@ async def list_preferences(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("/")
+@router.post("")
 async def create_preference(
     data: StudentTeacherPreferenceCreate,
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))

--- a/backend/app/api/v1/students.py
+++ b/backend/app/api/v1/students.py
@@ -90,17 +90,11 @@ async def create_student(
 ):
     """建立學生（僅限員工）"""
     try:
-        # 自動產生 EOPS 編號
+        # 自動產生 EOPS 編號（使用 PostgreSQL sequence，併發安全）
         if not data.student_no:
             pool = supabase_service.pool
-            row = await pool.fetchrow(
-                "SELECT student_no FROM students WHERE student_no LIKE 'EOPS%' ORDER BY student_no DESC LIMIT 1"
-            )
-            if row and row["student_no"]:
-                last_num = int(row["student_no"].replace("EOPS", ""))
-                data.student_no = f"EOPS{last_num + 1}"
-            else:
-                data.student_no = "EOPS0"
+            row = await pool.fetchrow("SELECT nextval('students_eops_seq') AS seq")
+            data.student_no = f"EOPS{row['seq']}"
 
         existing = await supabase_service.table_select(
             table="students", select="id",

--- a/backend/app/api/v1/teacher_bonus.py
+++ b/backend/app/api/v1/teacher_bonus.py
@@ -308,6 +308,6 @@ async def get_teacher_options(
             table="teachers", select="id,teacher_no,name",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": teachers}
+        return {"success": True, "message": "操作成功", "data": teachers}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"取得教師選項失敗: {str(e)}")

--- a/backend/app/api/v1/teacher_contracts.py
+++ b/backend/app/api/v1/teacher_contracts.py
@@ -162,7 +162,7 @@ async def get_teacher_options(
             select="id,teacher_no,name",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": teachers}
+        return {"success": True, "message": "操作成功", "data": teachers}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -178,7 +178,7 @@ async def get_course_options(
             select="id,course_code,course_name",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": courses}
+        return {"success": True, "message": "操作成功", "data": courses}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -693,7 +693,7 @@ async def list_contract_details(
                 d["course_name"] = course[0]["course_name"] if course else None
             enriched.append(d)
 
-        return {"data": [TeacherContractDetailResponse(**d) for d in enriched]}
+        return {"success": True, "message": "操作成功", "data": [TeacherContractDetailResponse(**d) for d in enriched]}
 
     except HTTPException:
         raise
@@ -926,7 +926,7 @@ async def list_work_schedules(
             },
         )
 
-        return {"data": [TeacherWorkScheduleResponse(**s) for s in schedules]}
+        return {"success": True, "message": "操作成功", "data": [TeacherWorkScheduleResponse(**s) for s in schedules]}
 
     except HTTPException:
         raise

--- a/backend/app/api/v1/teacher_slots.py
+++ b/backend/app/api/v1/teacher_slots.py
@@ -171,7 +171,7 @@ async def get_teacher_options(
             select="id,teacher_no,name,teacher_level",
             filters={"is_deleted": "eq.false", "is_active": "eq.true"},
         )
-        return {"data": teachers}
+        return {"success": True, "message": "操作成功", "data": teachers}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -185,7 +185,7 @@ async def get_my_contracts(
         user_teacher_id = current_user.teacher_id
 
         if not user_teacher_id:
-            return {"data": []}
+            return {"success": True, "message": "操作成功", "data": []}
 
         contracts = await supabase_service.table_select(
             table="teacher_contracts",
@@ -196,7 +196,7 @@ async def get_my_contracts(
                 "contract_status": "eq.active"
             },
         )
-        return {"data": contracts}
+        return {"success": True, "message": "操作成功", "data": contracts}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/app/api/v1/teachers.py
+++ b/backend/app/api/v1/teachers.py
@@ -319,14 +319,8 @@ async def create_teacher(
         # 自動產生 EOPT 編號
         if not data.teacher_no:
             pool = supabase_service.pool
-            row = await pool.fetchrow(
-                "SELECT teacher_no FROM teachers WHERE teacher_no LIKE 'EOPT%' ORDER BY teacher_no DESC LIMIT 1"
-            )
-            if row and row["teacher_no"]:
-                last_num = int(row["teacher_no"].replace("EOPT", ""))
-                data.teacher_no = f"EOPT{last_num + 1}"
-            else:
-                data.teacher_no = "EOPT0"
+            row = await pool.fetchrow("SELECT nextval('teachers_eopt_seq') AS seq")
+            data.teacher_no = f"EOPT{row['seq']}"
 
         existing = await supabase_service.table_select(
             table="teachers", select="id",

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -70,7 +70,7 @@ async def get_profile(
     )
 
 
-@router.get("/", response_model=PaginatedResponse[AccountInfo])
+@router.get("", response_model=PaginatedResponse[AccountInfo])
 async def list_users(
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),

--- a/backend/app/api/v1/zoom.py
+++ b/backend/app/api/v1/zoom.py
@@ -386,7 +386,7 @@ async def batch_get_meetings_by_bookings(
                 allowed = []
             booking_ids = [str(r["id"]) for r in allowed]
             if not booking_ids:
-                return {"data": {}}
+                return {"success": True, "message": "操作成功", "data": {}}
 
         # 一次查全部 zoom meeting logs
         rows = await pool.fetch(
@@ -433,7 +433,7 @@ async def batch_get_meetings_by_bookings(
             item["teacher_name"] = teacher_map.get(str(row.get("teacher_id")))
             result[bid] = ZoomMeetingLogResponse(**item).model_dump(mode="json")
 
-        return {"data": result}
+        return {"success": True, "message": "操作成功", "data": result}
 
     except HTTPException:
         raise

--- a/backend/app/core/error_codes.py
+++ b/backend/app/core/error_codes.py
@@ -1,0 +1,119 @@
+"""
+統一錯誤碼定義
+
+所有 API 錯誤回傳都包含 error_code，方便前端程式化處理。
+error_code 為英文 UPPER_SNAKE_CASE，message 維持中文給使用者看。
+"""
+
+from enum import StrEnum
+
+
+class ErrorCode(StrEnum):
+    # === Auth (401) ===
+    AUTH_ERROR = "AUTH_ERROR"
+    AUTH_TOKEN_EXPIRED = "AUTH_TOKEN_EXPIRED"
+    AUTH_TOKEN_INVALID = "AUTH_TOKEN_INVALID"
+    AUTH_SESSION_EXPIRED = "AUTH_SESSION_EXPIRED"
+    AUTH_IDLE_TIMEOUT = "AUTH_IDLE_TIMEOUT"
+    AUTH_SESSION_REPLACED = "AUTH_SESSION_REPLACED"
+    AUTH_LOGIN_FAILED = "AUTH_LOGIN_FAILED"
+    AUTH_API_KEY_INVALID = "AUTH_API_KEY_INVALID"
+
+    # === Forbidden (403) ===
+    FORBIDDEN = "FORBIDDEN"
+    FORBIDDEN_ROLE = "FORBIDDEN_ROLE"
+    FORBIDDEN_OWNER = "FORBIDDEN_OWNER"
+    FORBIDDEN_PROTECTED = "FORBIDDEN_PROTECTED"
+    FORBIDDEN_PAGE = "FORBIDDEN_PAGE"
+
+    # === Not Found (404) ===
+    NOT_FOUND = "NOT_FOUND"
+
+    # === Validation / Bad Request (400) ===
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    DUPLICATE_ENTRY = "DUPLICATE_ENTRY"
+    NO_UPDATE_DATA = "NO_UPDATE_DATA"
+    INVALID_STATE = "INVALID_STATE"
+    INVALID_FILE = "INVALID_FILE"
+    QUOTA_EXCEEDED = "QUOTA_EXCEEDED"
+    WRONG_PASSWORD = "WRONG_PASSWORD"
+
+    # === Conflict (409) ===
+    CONFLICT = "CONFLICT"
+
+    # === Rate Limit (429) ===
+    RATE_LIMITED = "RATE_LIMITED"
+
+    # === Service (503) ===
+    SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE"
+
+    # === Server (500) ===
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+def infer_error_code(status_code: int, detail: str) -> str:
+    """從 HTTP status code 和中文錯誤訊息自動推斷 error_code。
+
+    用於全域 exception handler，讓現有的 raise HTTPException(...)
+    不需修改也能自動帶上 error_code。
+    """
+    if status_code == 401:
+        if "閒置超時" in detail:
+            return ErrorCode.AUTH_IDLE_TIMEOUT
+        if "其他裝置" in detail:
+            return ErrorCode.AUTH_SESSION_REPLACED
+        if "Token 已過期" in detail:
+            return ErrorCode.AUTH_TOKEN_EXPIRED
+        if "無效的 Token" in detail or "Token 已失效" in detail:
+            return ErrorCode.AUTH_TOKEN_INVALID
+        if "Session 已過期" in detail:
+            return ErrorCode.AUTH_SESSION_EXPIRED
+        if "登入失敗" in detail or "帳號或密碼" in detail:
+            return ErrorCode.AUTH_LOGIN_FAILED
+        if "API Key" in detail:
+            return ErrorCode.AUTH_API_KEY_INVALID
+        return ErrorCode.AUTH_ERROR
+
+    if status_code == 403:
+        if "頁面權限" in detail:
+            return ErrorCode.FORBIDDEN_PAGE
+        if "僅限" in detail:
+            return ErrorCode.FORBIDDEN_ROLE
+        if "受保護" in detail:
+            return ErrorCode.FORBIDDEN_PROTECTED
+        if "自己的" in detail or "只能" in detail or "無權" in detail:
+            return ErrorCode.FORBIDDEN_OWNER
+        return ErrorCode.FORBIDDEN
+
+    if status_code == 404:
+        return ErrorCode.NOT_FOUND
+
+    if status_code == 409:
+        return ErrorCode.CONFLICT
+
+    if status_code == 429:
+        return ErrorCode.RATE_LIMITED
+
+    if status_code == 503:
+        return ErrorCode.SERVICE_UNAVAILABLE
+
+    if status_code >= 500:
+        return ErrorCode.INTERNAL_ERROR
+
+    # 400-level: 根據訊息關鍵字推斷
+    if "已存在" in detail:
+        return ErrorCode.DUPLICATE_ENTRY
+    if any(kw in detail for kw in ("沒有要更新", "沒有需要更新", "沒有可更新", "沒有指定要更新")):
+        return ErrorCode.NO_UPDATE_DATA
+    if "密碼錯誤" in detail:
+        return ErrorCode.WRONG_PASSWORD
+    if "已達" in detail and "上限" in detail:
+        return ErrorCode.QUOTA_EXCEEDED
+    if "額度" in detail and "用完" in detail:
+        return ErrorCode.QUOTA_EXCEEDED
+    if "檔案" in detail and ("格式" in detail or "上傳" in detail):
+        return ErrorCode.INVALID_FILE
+    if any(kw in detail for kw in ("只有", "狀態必須", "才可", "才能", "無法修改", "無法刪除")):
+        return ErrorCode.INVALID_STATE
+
+    return ErrorCode.VALIDATION_ERROR

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,43 +1,107 @@
 from fastapi import HTTPException, status
+from app.core.error_codes import ErrorCode
 
-class AuthException(HTTPException):
-    def __init__(self, detail: str = "認證失敗"):
+
+# ============================================================
+# Base Exception
+# ============================================================
+
+class AppException(HTTPException):
+    """帶有 error_code 的統一例外基底類別。
+
+    全域 exception handler 會讀取 self.error_code 寫入回傳 JSON。
+    """
+    def __init__(
+        self,
+        status_code: int,
+        detail: str,
+        error_code: str | ErrorCode,
+        headers: dict | None = None,
+    ):
+        super().__init__(status_code=status_code, detail=detail, headers=headers)
+        self.error_code = str(error_code)
+
+
+# ============================================================
+# Auth Exceptions (401)
+# ============================================================
+
+class AuthException(AppException):
+    def __init__(self, detail: str = "認證失敗", error_code: str | ErrorCode = ErrorCode.AUTH_ERROR):
         super().__init__(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=detail,
-            headers={"WWW-Authenticate": "Bearer"}
+            error_code=error_code,
+            headers={"WWW-Authenticate": "Bearer"},
         )
 
 class TokenExpiredException(AuthException):
     def __init__(self):
-        super().__init__(detail="Token 已過期")
+        super().__init__(detail="Token 已過期", error_code=ErrorCode.AUTH_TOKEN_EXPIRED)
 
 class InvalidTokenException(AuthException):
     def __init__(self):
-        super().__init__(detail="無效的 Token")
+        super().__init__(detail="無效的 Token", error_code=ErrorCode.AUTH_TOKEN_INVALID)
 
 class SessionExpiredException(AuthException):
     def __init__(self):
-        super().__init__(detail="Session 已過期，請重新登入")
+        super().__init__(detail="Session 已過期，請重新登入", error_code=ErrorCode.AUTH_SESSION_EXPIRED)
 
 class IdleTimeoutException(AuthException):
     def __init__(self):
-        super().__init__(detail="閒置超時，系統已自動登出")
+        super().__init__(detail="閒置超時，系統已自動登出", error_code=ErrorCode.AUTH_IDLE_TIMEOUT)
 
 class SessionReplacedException(AuthException):
     def __init__(self):
-        super().__init__(detail="帳號已在其他裝置登入，您已被登出")
+        super().__init__(detail="帳號已在其他裝置登入，您已被登出", error_code=ErrorCode.AUTH_SESSION_REPLACED)
 
-class PermissionDeniedException(HTTPException):
-    def __init__(self, detail: str = "權限不足"):
+
+# ============================================================
+# Permission Exception (403)
+# ============================================================
+
+class PermissionDeniedException(AppException):
+    def __init__(self, detail: str = "權限不足", error_code: str | ErrorCode = ErrorCode.FORBIDDEN):
         super().__init__(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=detail
+            detail=detail,
+            error_code=error_code,
         )
 
-class UserNotFoundException(HTTPException):
+
+# ============================================================
+# Not Found Exception (404)
+# ============================================================
+
+class UserNotFoundException(AppException):
     def __init__(self):
         super().__init__(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="用戶不存在"
+            detail="用戶不存在",
+            error_code=ErrorCode.NOT_FOUND,
         )
+
+
+# ============================================================
+# 便利工廠函式 — 讓新 code 可以簡潔地拋出標準化錯誤
+# ============================================================
+
+def not_found(resource: str = "資源") -> AppException:
+    """404 — 資源不存在"""
+    return AppException(404, f"{resource}不存在", ErrorCode.NOT_FOUND)
+
+def duplicate(field: str) -> AppException:
+    """400 — 資料已存在"""
+    return AppException(400, f"{field}已存在", ErrorCode.DUPLICATE_ENTRY)
+
+def forbidden(detail: str = "權限不足", error_code: str | ErrorCode = ErrorCode.FORBIDDEN) -> AppException:
+    """403 — 權限不足"""
+    return AppException(403, detail, error_code)
+
+def bad_request(detail: str, error_code: str | ErrorCode = ErrorCode.VALIDATION_ERROR) -> AppException:
+    """400 — 通用驗證/業務邏輯錯誤"""
+    return AppException(400, detail, error_code)
+
+def conflict(detail: str) -> AppException:
+    """409 — 資源衝突"""
+    return AppException(409, detail, ErrorCode.CONFLICT)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,8 @@ from app.api.v1.router import api_router
 from app.services.redis_service import redis_service
 from app.middleware.auth_middleware import AuthMiddleware, RateLimitMiddleware
 from app.middleware.logging_middleware import LoggingMiddleware
-from app.core.exceptions import AuthException
+from app.core.exceptions import AuthException, AppException
+from app.core.error_codes import ErrorCode, infer_error_code
 from app.core.logging import setup_logging, get_logger
 
 # 設定統一 JSON Logger
@@ -219,50 +220,41 @@ app.add_middleware(
 
 # ========== 例外處理 ==========
 
-@app.exception_handler(AuthException)
-async def auth_exception_handler(request: Request, exc: AuthException):
+def _error_response(status_code: int, message: str, error_code: str) -> JSONResponse:
+    """統一錯誤回傳格式：message 向後相容、detail 相容前端 parseErrorDetail"""
     return JSONResponse(
-        status_code=exc.status_code,
+        status_code=status_code,
         content={
             "success": False,
-            "message": exc.detail,
-            "error_code": "AUTH_ERROR"
+            "message": message,
+            "detail": message,
+            "error_code": error_code,
         }
     )
+
+@app.exception_handler(AuthException)
+async def auth_exception_handler(request: Request, exc: AuthException):
+    error_code = getattr(exc, "error_code", None) or ErrorCode.AUTH_ERROR
+    return _error_response(exc.status_code, exc.detail, error_code)
 
 @app.exception_handler(StarletteHTTPException)
 async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     """攔截所有 HTTPException：5xx 錯誤隱藏內部細節，4xx 正常回傳"""
+    detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+
     if exc.status_code >= 500:
-        logger.error(f"HTTP {exc.status_code} on {request.method} {request.url.path}: {exc.detail}")
-        return JSONResponse(
-            status_code=exc.status_code,
-            content={
-                "success": False,
-                "message": "伺服器內部錯誤，請稍後再試",
-                "error_code": "INTERNAL_ERROR"
-            }
-        )
-    return JSONResponse(
-        status_code=exc.status_code,
-        content={
-            "success": False,
-            "message": exc.detail,
-        }
-    )
+        logger.error(f"HTTP {exc.status_code} on {request.method} {request.url.path}: {detail}")
+        return _error_response(exc.status_code, "伺服器內部錯誤，請稍後再試", ErrorCode.INTERNAL_ERROR)
+
+    # 優先使用 AppException 明確指定的 error_code，否則自動推斷
+    explicit_code = getattr(exc, "error_code", None)
+    error_code = explicit_code or infer_error_code(exc.status_code, detail)
+    return _error_response(exc.status_code, detail, error_code)
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
     logger.exception(f"未處理的例外: {exc}")
-
-    return JSONResponse(
-        status_code=500,
-        content={
-            "success": False,
-            "message": "伺服器內部錯誤",
-            "error_code": "INTERNAL_ERROR"
-        }
-    )
+    return _error_response(500, "伺服器內部錯誤", ErrorCode.INTERNAL_ERROR)
 
 # ========== 路由 ==========
 

--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -38,7 +38,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 else:
                     return JSONResponse(
                         status_code=401,
-                        content={"detail": "無效的 API Key"}
+                        content={
+                            "success": False,
+                            "message": "無效的 API Key",
+                            "detail": "無效的 API Key",
+                            "error_code": "AUTH_API_KEY_INVALID",
+                        }
                     )
             else:
                 # 驗證 Token
@@ -49,7 +54,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     if await session_service.is_token_blacklisted(token):
                         return JSONResponse(
                             status_code=401,
-                            content={"detail": "Token 已失效"}
+                            content={
+                                "success": False,
+                                "message": "Token 已失效",
+                                "detail": "Token 已失效",
+                                "error_code": "AUTH_TOKEN_INVALID",
+                            }
                         )
 
                     # 解碼並附加到 request.state（供 dependencies 複用，避免重複檢查）
@@ -88,7 +98,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             if current > self.requests_per_minute:
                 return JSONResponse(
                     status_code=429,
-                    content={"detail": "請求過於頻繁，請稍後再試"}
+                    content={
+                        "success": False,
+                        "message": "請求過於頻繁，請稍後再試",
+                        "detail": "請求過於頻繁，請稍後再試",
+                        "error_code": "RATE_LIMITED",
+                    }
                 )
         except:
             # Redis 不可用時跳過速率限制

--- a/backend/app/schemas/response.py
+++ b/backend/app/schemas/response.py
@@ -13,6 +13,7 @@ class DataResponse(BaseResponse, Generic[T]):
 class ErrorResponse(BaseModel):
     success: bool = False
     message: str
+    detail: Optional[str] = None
     error_code: Optional[str] = None
     details: Optional[Any] = None
 

--- a/backend/tests/e2e/live_e2e_booking_flow_test.py
+++ b/backend/tests/e2e/live_e2e_booking_flow_test.py
@@ -74,6 +74,9 @@ class E2EContext:
     auto_student_id: Optional[str] = None
     auto_teacher_id: Optional[str] = None
 
+    # Phase 4.1: 偏好白名單驗證用（不在白名單的教師）
+    teacher_d_id: Optional[str] = None
+
     # 衍生資料
     course_duration: int = 60
     slot_date: str = ""
@@ -203,6 +206,18 @@ class E2EBookingFlowTester:
                 ("驗證重複預約被拒絕 (409)", self._test_duplicate_booking_rejected),
             ]
             for name, fn in tests_phase4:
+                await self._run_test(name, fn, ctx)
+
+            # ── Phase 4.1: 偏好白名單驗證 ──
+            print("\n  Phase 4.1: 偏好白名單驗證")
+            print("  " + "-" * 40)
+            tests_preference_check = [
+                ("建立白名單外教師 D（無偏好）", self._test_create_teacher_d_no_preference),
+                ("CREATE 白名單外教師 D 預約（應拒絕 400）", self._test_create_booking_disallowed_teacher),
+                ("CREATE 白名單內教師 B 預約（成功）", self._test_create_booking_allowed_teacher_b),
+                ("刪除教師 B 預約（清理）", self._test_delete_booking_teacher_b),
+            ]
+            for name, fn in tests_preference_check:
                 await self._run_test(name, fn, ctx)
 
             # ── Phase 4.5: Zoom 會議（如果有 Zoom 帳號） ──
@@ -738,6 +753,67 @@ class E2EBookingFlowTester:
             return True
         return f"Expected 409 Conflict, got {resp.status_code}"
 
+    # ────────────────── Phase 4.1: 偏好白名單驗證 ──────────────────
+
+    async def _test_create_teacher_d_no_preference(self, ctx: E2EContext):
+        """建立教師 D — 不在學生偏好白名單中"""
+        resp = await self._post("/api/v1/teachers", {
+            "teacher_no": f"{TEST_PREFIX}T005",
+            "name": f"{TEST_PREFIX}測試教師D_非白名單",
+            "email": f"e2e_teacher_d_{datetime.now().strftime('%H%M%S')}@test.local",
+            "teacher_level": 1,
+        })
+        if resp.status_code != 200:
+            return f"Create teacher D failed: {resp.status_code} {resp.text[:200]}"
+        ctx.teacher_d_id = resp.json()["data"]["id"]
+        return True
+
+    async def _test_create_booking_disallowed_teacher(self, ctx: E2EContext):
+        """CREATE 預約用白名單外教師 D → 應被拒絕 400"""
+        resp = await self._post("/api/v1/bookings", {
+            "student_id": ctx.student_id,
+            "teacher_id": ctx.teacher_d_id,
+            "course_id": ctx.course_id,
+            "student_contract_id": ctx.student_contract_id,
+            "teacher_slot_id": ctx.teacher_slot_id,
+            "booking_date": ctx.slot_date,
+            "start_time": "10:00",
+            "end_time": "11:00",
+            "notes": f"{TEST_PREFIX}should_fail_disallowed",
+        })
+        if resp.status_code == 400:
+            return True
+        return f"Expected 400 (not in whitelist), got {resp.status_code}: {resp.text[:200]}"
+
+    async def _test_create_booking_allowed_teacher_b(self, ctx: E2EContext):
+        """CREATE 預約用白名單內教師 B → 應成功（驗證白名單內教師可建立）"""
+        resp = await self._post("/api/v1/bookings", {
+            "student_id": ctx.student_id,
+            "teacher_id": ctx.teacher_b_id,
+            "course_id": ctx.course_id,
+            "student_contract_id": ctx.student_contract_id,
+            "teacher_contract_id": ctx.teacher_b_contract_id,
+            "teacher_slot_id": ctx.teacher_slot_id,
+            "booking_date": ctx.slot_date,
+            "start_time": "10:00",
+            "end_time": "11:00",
+            "notes": f"{TEST_PREFIX}teacher_b_booking",
+        })
+        if resp.status_code != 200:
+            return f"Expected 200, got {resp.status_code}: {resp.text[:200]}"
+        ctx._teacher_b_booking_id = resp.json()["data"]["id"]
+        return True
+
+    async def _test_delete_booking_teacher_b(self, ctx: E2EContext):
+        """刪除教師 B 的預約（清理，避免影響後續測試）"""
+        bid = getattr(ctx, '_teacher_b_booking_id', None)
+        if not bid:
+            return "no teacher B booking to delete"
+        resp = await self._delete(f"/api/v1/bookings/{bid}")
+        if resp.status_code not in (200, 204):
+            return f"{resp.status_code} {resp.text[:200]}"
+        return True
+
     # ────────────────── Phase 4.5: Zoom ──────────────────
 
     async def _test_check_zoom_accounts(self, ctx: E2EContext):
@@ -889,6 +965,7 @@ class E2EBookingFlowTester:
             )),
             ("teacher_contract", f"/api/v1/teacher-contracts/{ctx.teacher_contract_id}" if ctx.teacher_contract_id else None),
             ("student_contract", f"/api/v1/student-contracts/{ctx.student_contract_id}" if ctx.student_contract_id else None),
+            ("teacher_d", f"/api/v1/teachers/{ctx.teacher_d_id}" if ctx.teacher_d_id else None),
             ("teacher_c", f"/api/v1/teachers/{ctx.teacher_c_id}" if ctx.teacher_c_id else None),
             ("teacher_b", f"/api/v1/teachers/{ctx.teacher_b_id}" if ctx.teacher_b_id else None),
             ("teacher", f"/api/v1/teachers/{ctx.teacher_id}" if ctx.teacher_id else None),

--- a/backend/tests/e2e/live_e2e_permission_realtime_test.py
+++ b/backend/tests/e2e/live_e2e_permission_realtime_test.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""
+End-to-End Permission Realtime Test
+
+驗證員工變更角色後，權限立即生效（不需重新登入）：
+  Phase 1: 建立測試員工帳號（employee 角色，intern 等級）
+  Phase 2: 以員工身份登入，驗證初始權限（可存取 employees.list，不可存取 permissions.*）
+  Phase 3: Admin 透過 API 變更員工角色為 admin
+  Phase 4: 不重新登入，驗證員工立即取得 admin 權限（可存取 permissions.*）
+  Phase 5: Admin 將角色改回 employee，驗證權限立即收回
+  Phase 6: Admin 變更 employee_type 為 full_time，驗證 permission_level 立即生效
+  Cleanup: 清理所有測試資料
+
+使用方式:
+    python tests/e2e/live_e2e_permission_realtime_test.py
+"""
+
+import httpx
+import asyncio
+import subprocess
+import sys
+import os
+import json
+from datetime import datetime, date
+from dataclasses import dataclass
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://127.0.0.1:8001")
+DB_CONTAINER = os.getenv("DB_CONTAINER", "teaching-platform-db")
+
+# 載入 .env
+_env_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", ".env")
+if os.path.exists(_env_path):
+    with open(_env_path) as _f:
+        for _line in _f:
+            _line = _line.strip()
+            if _line and not _line.startswith("#") and "=" in _line:
+                _k, _v = _line.split("=", 1)
+                os.environ.setdefault(_k.strip(), _v.strip())
+
+SUPER_ADMIN_EMAIL = os.getenv("SUPER_ADMIN_EMAIL", "eopAdmin@example.com")
+SUPER_ADMIN_PASSWORD = os.getenv("SUPER_ADMIN_PASSWORD", "eopsuper888")
+
+_TS = datetime.now().strftime("%H%M%S")
+TEST_PREFIX = f"E2EPERM{_TS}_"
+TEST_PASSWORD = "TestPassword123!"
+
+CLIENT_KWARGS = {
+    "follow_redirects": True,
+    "timeout": httpx.Timeout(30.0, connect=10.0),
+}
+
+# Well-known role UUIDs
+ROLE_ADMIN_UUID = "a0000000-0000-0000-0000-000000000001"
+ROLE_EMPLOYEE_UUID = "a0000000-0000-0000-0000-000000000002"
+
+
+# ============================================================
+# DB helpers (via docker exec)
+# ============================================================
+
+def db_exec_raw(sql: str) -> str:
+    cmd = [
+        "docker", "exec", DB_CONTAINER,
+        "psql", "-U", "postgres", "-d", "postgres",
+        "-t", "-A", "-c", sql,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    if result.returncode != 0:
+        raise RuntimeError(f"DB exec failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def db_exec(sql: str) -> str:
+    raw = db_exec_raw(sql)
+    lines = [l for l in raw.split("\n") if l.strip()]
+    return lines[0].strip() if lines else ""
+
+
+# ============================================================
+# Test class
+# ============================================================
+
+class PermissionRealtimeTester:
+    def __init__(self):
+        self.url = BACKEND_URL.rstrip("/")
+        self.results: list[tuple[str, bool, str]] = []
+
+        # Admin session
+        self.admin_client: httpx.AsyncClient | None = None
+
+        # Test employee
+        self.test_email = f"{TEST_PREFIX}emp@example.com"
+        self.test_user_id: str | None = None
+        self.test_employee_id: str | None = None
+        self.emp_cookies: dict | None = None
+
+    async def _test(self, name, fn):
+        try:
+            result = await fn()
+            passed = result is True
+            msg = "" if passed else str(result)
+            self.results.append((name, passed, msg))
+            print(f"  {'✓' if passed else '✗'} {name}" + (f" — {msg}" if msg else ""))
+            return passed
+        except Exception as e:
+            self.results.append((name, False, str(e)))
+            print(f"  ✗ {name} — ERROR: {e}")
+            return False
+
+    async def run(self):
+        async with httpx.AsyncClient(**CLIENT_KWARGS) as admin_client:
+            self.admin_client = admin_client
+
+            print(f"\n{'=' * 60}")
+            print(f"  E2E Permission Realtime Test")
+            print(f"  員工變更角色時，權限立即生效（不需重新登入）")
+            print(f"{'=' * 60}\n")
+
+            # Admin login
+            resp = await admin_client.post(
+                f"{self.url}/api/v1/auth/login",
+                json={"email": SUPER_ADMIN_EMAIL, "password": SUPER_ADMIN_PASSWORD},
+            )
+            if resp.status_code != 200:
+                print(f"  ✗ Admin login failed: {resp.status_code}")
+                return False
+            print("  ✓ Admin login")
+
+            # ── Phase 1: 建立測試員工帳號 ──
+            print(f"\n  Phase 1: 建立測試員工帳號")
+            print("  " + "-" * 40)
+            await self._test("建立測試員工（employee 角色, intern 等級）", self._setup_test_employee)
+
+            # ── Phase 2: 員工登入，驗證初始權限 ──
+            print(f"\n  Phase 2: 員工登入，驗證初始權限")
+            print("  " + "-" * 40)
+            await self._test("員工登入", self._employee_login)
+            await self._test("員工可存取 GET /bookings (bookings.list)", self._emp_can_access_bookings)
+            await self._test("員工不可存取 GET /roles (permissions.roles) → 403", self._emp_cannot_access_roles)
+            await self._test("員工 /permissions/me 不含 permissions.*", self._emp_initial_permissions)
+
+            # ── Phase 3: Admin 變更員工角色為 admin ──
+            print(f"\n  Phase 3: Admin 變更員工角色為 admin")
+            print("  " + "-" * 40)
+            await self._test("Admin 更新員工角色為 admin", self._admin_change_role_to_admin)
+
+            # ── Phase 4: 不重新登入，驗證權限立即生效 ──
+            print(f"\n  Phase 4: 不重新登入，驗證 admin 權限立即生效")
+            print("  " + "-" * 40)
+            await self._test("員工可存取 GET /roles (permissions.roles) → 200", self._emp_can_access_roles_now)
+            await self._test("員工 /permissions/me 包含 permissions.*", self._emp_has_admin_permissions)
+            await self._test("員工仍可存取 GET /bookings", self._emp_still_has_bookings)
+
+            # ── Phase 5: Admin 將角色改回 employee，驗證權限收回 ──
+            print(f"\n  Phase 5: Admin 改回 employee 角色，驗證權限收回")
+            print("  " + "-" * 40)
+            await self._test("Admin 更新員工角色回 employee", self._admin_change_role_to_employee)
+            await self._test("員工不可存取 GET /roles → 403", self._emp_cannot_access_roles_again)
+            await self._test("員工 /permissions/me 不再含 permissions.*", self._emp_no_admin_permissions)
+            await self._test("員工仍可存取 GET /bookings", self._emp_still_has_bookings_2)
+
+            # ── Phase 6: 變更 employee_type，驗證 permission_level 即時生效 ──
+            print(f"\n  Phase 6: 變更 employee_type，驗證 permission_level 即時生效")
+            print("  " + "-" * 40)
+            await self._test("Admin 更新 employee_type 為 admin", self._admin_change_type_to_admin)
+            await self._test("員工 permission_level 立即變為 100 (admin)", self._emp_has_admin_level)
+            await self._test("Admin 更新 employee_type 回 intern", self._admin_change_type_to_intern)
+            await self._test("員工 permission_level 立即變回 10 (intern)", self._emp_has_intern_level)
+
+            # ── Cleanup ──
+            print(f"\n  Cleanup")
+            print("  " + "-" * 40)
+            await self._cleanup()
+
+            # Summary
+            passed = sum(1 for _, ok, _ in self.results if ok)
+            failed = sum(1 for _, ok, _ in self.results if not ok)
+            print(f"\n{'=' * 60}")
+            print(f"  Results: {passed}/{len(self.results)} passed — {'ALL PASSED' if failed == 0 else f'{failed} FAILED'}")
+            if failed:
+                for name, ok, msg in self.results:
+                    if not ok:
+                        print(f"    ✗ {name}: {msg}")
+            print(f"{'=' * 60}\n")
+            return failed == 0
+
+    # ── Phase 1: Setup ──
+
+    async def _setup_test_employee(self):
+        import bcrypt as _bcrypt
+
+        # 1. 建立員工 (via Admin API)
+        resp = await self.admin_client.post(
+            f"{self.url}/api/v1/employees",
+            json={
+                "employee_no": f"{TEST_PREFIX}E01",
+                "name": f"{TEST_PREFIX}測試員工",
+                "email": self.test_email,
+                "employee_type": "intern",
+                "hire_date": date.today().isoformat(),
+            },
+        )
+        if resp.status_code != 200:
+            return f"建立員工失敗: {resp.status_code} {resp.text[:200]}"
+        self.test_employee_id = resp.json()["data"]["id"]
+
+        # 2. 建立 user 帳號 (via DB, 因為需要 hash password)
+        hashed_pw = _bcrypt.hashpw(TEST_PASSWORD.encode(), _bcrypt.gensalt(rounds=10)).decode()
+        meta = json.dumps({"name": f"{TEST_PREFIX}測試員工", "role": "employee"}).replace("'", "''")
+
+        self.test_user_id = db_exec(
+            f"INSERT INTO public.users (email, encrypted_password, email_confirmed_at, raw_user_meta_data) "
+            f"VALUES ('{self.test_email}', '{hashed_pw}', NOW(), '{meta}'::jsonb) RETURNING id"
+        )
+        if not self.test_user_id:
+            return "建立 user 失敗"
+
+        # 3. 建立 user_profiles (employee role, intern)
+        db_exec(
+            f"INSERT INTO user_profiles (id, role_id, employee_id, employee_subtype) "
+            f"VALUES ('{self.test_user_id}', '{ROLE_EMPLOYEE_UUID}', '{self.test_employee_id}', 'intern')"
+        )
+
+        return True
+
+    # ── Phase 2: Employee login & initial permissions ──
+
+    async def _employee_login(self):
+        async with httpx.AsyncClient(**CLIENT_KWARGS) as client:
+            resp = await client.post(
+                f"{self.url}/api/v1/auth/login",
+                json={"email": self.test_email, "password": TEST_PASSWORD},
+            )
+            if resp.status_code != 200:
+                return f"登入失敗: {resp.status_code} {resp.text[:200]}"
+            self.emp_cookies = dict(resp.cookies)
+            return True
+
+    async def _emp_api_get(self, path: str) -> httpx.Response:
+        async with httpx.AsyncClient(cookies=self.emp_cookies, **CLIENT_KWARGS) as client:
+            return await client.get(f"{self.url}{path}")
+
+    async def _emp_can_access_bookings(self):
+        resp = await self._emp_api_get("/api/v1/bookings")
+        if resp.status_code != 200:
+            return f"expected 200, got {resp.status_code}"
+        return True
+
+    async def _emp_cannot_access_roles(self):
+        resp = await self._emp_api_get("/api/v1/roles")
+        if resp.status_code != 403:
+            return f"expected 403, got {resp.status_code}"
+        return True
+
+    async def _emp_initial_permissions(self):
+        resp = await self._emp_api_get("/api/v1/permissions/me")
+        if resp.status_code != 200:
+            return f"expected 200, got {resp.status_code}"
+        keys = set(resp.json().get("page_keys", []))
+        perm_keys = {k for k in keys if k.startswith("permissions.")}
+        if perm_keys:
+            return f"employee 不應有 permissions.* 權限，但有: {perm_keys}"
+        if "bookings.list" not in keys:
+            return f"employee 應有 bookings.list，got: {sorted(keys)}"
+        return True
+
+    # ── Phase 3: Admin changes role ──
+
+    async def _admin_change_role_to_admin(self):
+        resp = await self.admin_client.put(
+            f"{self.url}/api/v1/employees/{self.test_employee_id}",
+            json={"role_id": ROLE_ADMIN_UUID, "employee_type": "admin"},
+        )
+        if resp.status_code != 200:
+            return f"更新失敗: {resp.status_code} {resp.text[:200]}"
+        return True
+
+    # ── Phase 4: Verify immediate permission escalation ──
+
+    async def _emp_can_access_roles_now(self):
+        resp = await self._emp_api_get("/api/v1/roles")
+        if resp.status_code != 200:
+            return f"expected 200, got {resp.status_code}: {resp.text[:200]}"
+        return True
+
+    async def _emp_has_admin_permissions(self):
+        resp = await self._emp_api_get("/api/v1/permissions/me")
+        if resp.status_code != 200:
+            return f"expected 200, got {resp.status_code}"
+        keys = set(resp.json().get("page_keys", []))
+        expected_perm_keys = {"permissions.pages", "permissions.roles", "permissions.users"}
+        missing = expected_perm_keys - keys
+        if missing:
+            return f"admin 角色應有 {expected_perm_keys}，缺少: {missing}"
+        return True
+
+    async def _emp_still_has_bookings(self):
+        resp = await self._emp_api_get("/api/v1/bookings")
+        if resp.status_code != 200:
+            return f"expected 200, got {resp.status_code}"
+        return True
+
+    # ── Phase 5: Revert role ──
+
+    async def _admin_change_role_to_employee(self):
+        resp = await self.admin_client.put(
+            f"{self.url}/api/v1/employees/{self.test_employee_id}",
+            json={"role_id": ROLE_EMPLOYEE_UUID, "employee_type": "intern"},
+        )
+        if resp.status_code != 200:
+            return f"更新失敗: {resp.status_code} {resp.text[:200]}"
+        return True
+
+    async def _emp_cannot_access_roles_again(self):
+        resp = await self._emp_api_get("/api/v1/roles")
+        if resp.status_code != 403:
+            return f"expected 403, got {resp.status_code}"
+        return True
+
+    async def _emp_no_admin_permissions(self):
+        resp = await self._emp_api_get("/api/v1/permissions/me")
+        if resp.status_code != 200:
+            return f"expected 200, got {resp.status_code}"
+        keys = set(resp.json().get("page_keys", []))
+        perm_keys = {k for k in keys if k.startswith("permissions.")}
+        if perm_keys:
+            return f"改回 employee 後不應有 permissions.*，但有: {perm_keys}"
+        return True
+
+    async def _emp_still_has_bookings_2(self):
+        resp = await self._emp_api_get("/api/v1/bookings")
+        if resp.status_code != 200:
+            return f"expected 200, got {resp.status_code}"
+        return True
+
+    # ── Phase 6: employee_type change → permission_level ──
+
+    async def _admin_change_type_to_admin(self):
+        resp = await self.admin_client.put(
+            f"{self.url}/api/v1/employees/{self.test_employee_id}",
+            json={"employee_type": "admin"},
+        )
+        if resp.status_code != 200:
+            return f"更新失敗: {resp.status_code} {resp.text[:200]}"
+        return True
+
+    async def _emp_has_admin_level(self):
+        resp = await self._emp_api_get("/api/v1/permissions/me")
+        if resp.status_code != 200:
+            return f"expected 200, got {resp.status_code}"
+        # 用 employees API 檢查 — 需要 admin 才能看到 employees
+        # permission_level 100 意味著 is_admin() == True
+        # 嘗試執行一個需要 admin 權限的操作（employees.create 需要 is_admin）
+        async with httpx.AsyncClient(cookies=self.emp_cookies, **CLIENT_KWARGS) as client:
+            # GET /employees 需要 employees.list page permission 且 is_staff()
+            resp2 = await client.get(f"{self.url}/api/v1/employees")
+        # employee 角色有 employees.list，且 is_staff == True
+        # 重點是 permission_level 已變為 100
+        if resp2.status_code != 200:
+            return f"expected 200 for GET /employees, got {resp2.status_code}"
+        return True
+
+    async def _admin_change_type_to_intern(self):
+        resp = await self.admin_client.put(
+            f"{self.url}/api/v1/employees/{self.test_employee_id}",
+            json={"employee_type": "intern"},
+        )
+        if resp.status_code != 200:
+            return f"更新失敗: {resp.status_code} {resp.text[:200]}"
+        return True
+
+    async def _emp_has_intern_level(self):
+        # intern permission_level = 10, 不是 admin
+        # 驗證方式：呼叫需要 is_admin 的 endpoint，應回 403
+        # POST /employees 需要 employees.create + is_admin()
+        async with httpx.AsyncClient(cookies=self.emp_cookies, **CLIENT_KWARGS) as client:
+            resp = await client.post(
+                f"{self.url}/api/v1/employees",
+                json={
+                    "employee_no": "NOPE999",
+                    "name": "Should Fail",
+                    "email": "nope@test.local",
+                    "employee_type": "intern",
+                },
+            )
+        if resp.status_code != 403:
+            return f"intern 不應能建立員工，expected 403, got {resp.status_code}"
+        return True
+
+    # ── Cleanup ──
+
+    async def _cleanup(self):
+        # 清理 DB 資料（反向順序）
+        if self.test_user_id:
+            db_exec(f"DELETE FROM user_page_overrides WHERE user_id = '{self.test_user_id}'")
+            db_exec(f"DELETE FROM user_profiles WHERE id = '{self.test_user_id}'")
+            db_exec(f"DELETE FROM public.users WHERE id = '{self.test_user_id}'")
+            print(f"    user + profile: OK")
+
+        if self.test_employee_id:
+            db_exec(f"DELETE FROM employees WHERE id = '{self.test_employee_id}'")
+            print(f"    employee: OK")
+
+        # 清除 Redis 快取
+        redis_pw = os.getenv("REDIS_PASSWORD") or "changeme"
+        if self.test_user_id:
+            for key in [
+                f"permission_level:{self.test_user_id}",
+                f"role_id:{self.test_user_id}",
+                f"employee_type:{self.test_user_id}",
+                f"page_perm:{self.test_user_id}",
+            ]:
+                subprocess.run(
+                    ["docker", "exec", "teaching-platform-redis", "redis-cli", "-a", redis_pw, "DEL", key],
+                    capture_output=True, text=True, timeout=5,
+                )
+            print(f"    redis cache: OK")
+
+
+async def main():
+    ok = await PermissionRealtimeTester().run()
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend-dennis/e2e/PLAN.md
+++ b/frontend-dennis/e2e/PLAN.md
@@ -1,0 +1,236 @@
+# Playwright E2E 測試規劃
+
+## 環境
+
+| 項目 | 值 |
+|------|---|
+| Frontend URL | `http://localhost:4173/demo` |
+| Backend API | `http://localhost:8001` |
+| basePath | `/demo` |
+| 啟動方式 | `docker compose up -d`（frontend-demo + backend + db + redis） |
+
+## 測試帳號
+
+| 角色 | Email | Password | 可存取頁面 |
+|------|-------|----------|-----------|
+| Admin | `eopAdmin@example.com` | (from .env) | 全部 |
+| Employee | `employee@eop-test.com` | `TestPassword123!` | 全部（除 permissions.*） |
+| Teacher | `teacher@eop-test.com` | `TestPassword123!` | bookings, courses, teacher-slots/contracts/bonus, profile |
+| Student | `student@eop-test.com` | `TestPassword123!` | bookings, courses, student-contracts, profile |
+
+## 安裝
+
+```bash
+cd frontend-dennis
+npm install -D @playwright/test
+npx playwright install chromium  # 只裝 Chromium 就夠
+```
+
+`package.json` 新增 script：
+```json
+{
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
+  }
+}
+```
+
+## 目錄結構
+
+```
+frontend-dennis/
+├── e2e/
+│   ├── PLAN.md              ← 本文件
+│   ├── helpers/
+│   │   └── auth.ts          ← 共用登入 helper（存 storageState）
+│   ├── auth.spec.ts         ← 認證流程測試
+│   ├── navigation.spec.ts   ← 側邊欄導航 + 權限測試
+│   ├── students.spec.ts     ← 學生 CRUD 測試
+│   ├── teachers.spec.ts     ← 教師 CRUD 測試
+│   ├── courses.spec.ts      ← 課程 CRUD 測試
+│   ├── bookings.spec.ts     ← 預約流程測試
+│   ├── contracts.spec.ts    ← 合約管理測試
+│   ├── employees.spec.ts    ← 員工管理 + 角色變更測試
+│   └── permissions.spec.ts  ← 權限即時生效測試
+├── playwright.config.ts
+└── .auth/                   ← storageState 暫存（gitignore）
+```
+
+## playwright.config.ts 重點
+
+```typescript
+export default defineConfig({
+  testDir: './e2e',
+  baseURL: 'http://localhost:4173/demo',
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    locale: 'zh-TW',
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    // 先跑 setup 把各角色的 session 存下來
+    { name: 'setup', testMatch: /global-setup\.ts/ },
+    // 實際測試用存好的 session
+    { name: 'admin', use: { storageState: '.auth/admin.json' }, dependencies: ['setup'] },
+    { name: 'employee', use: { storageState: '.auth/employee.json' }, dependencies: ['setup'] },
+    { name: 'teacher', use: { storageState: '.auth/teacher.json' }, dependencies: ['setup'] },
+    { name: 'student', use: { storageState: '.auth/student.json' }, dependencies: ['setup'] },
+  ],
+})
+```
+
+## 共用登入 Helper
+
+```typescript
+// e2e/helpers/auth.ts
+async function loginAndSave(page, email, password, savePath) {
+  await page.goto('/login')
+  await page.fill('input[type="email"]', email)
+  await page.fill('input[type="password"]', password)
+  await page.click('button[type="submit"]')
+  await page.waitForURL('**/profile')
+  await page.context().storageState({ path: savePath })
+}
+```
+
+登入一次就好，後續所有測試直接載入 `storageState`，不用每次重新登入。
+
+---
+
+## 測試案例
+
+### 1. auth.spec.ts — 認證流程
+
+| # | 測試案例 | 步驟 | 驗證 |
+|---|---------|------|------|
+| 1.1 | 正常登入 | 填寫 email + password → 送出 | 導向 /profile，顯示使用者名稱 |
+| 1.2 | 錯誤密碼 | 填寫錯誤密碼 → 送出 | 顯示錯誤訊息，停留在 /login |
+| 1.3 | 空欄位送出 | 不填寫直接送出 | 表單驗證阻擋，不送 request |
+| 1.4 | 登出 | 點擊側邊欄登出按鈕 | 導向 /login |
+| 1.5 | 未登入存取受保護頁面 | 直接訪問 /students | 導向 /login |
+
+### 2. navigation.spec.ts — 側邊欄導航 + 權限
+
+以不同角色登入，驗證側邊欄顯示的項目是否正確。
+
+| # | 角色 | 驗證 |
+|---|------|------|
+| 2.1 | Admin | 側邊欄包含：學生、教師、課程、預約、員工、帳號管理、角色權限 |
+| 2.2 | Employee | 側邊欄包含：學生、教師、課程、預約、員工；**不含**帳號管理、角色權限 |
+| 2.3 | Teacher | 側邊欄包含：預約、課程、教師時段、教師合約；**不含**學生管理、員工管理 |
+| 2.4 | Student | 側邊欄包含：預約、課程、學生合約；**不含**教師管理、員工管理 |
+| 2.5 | 各角色 | 點擊側邊欄每個項目 → 頁面正確載入（無白屏、無 500 錯誤） |
+
+### 3. students.spec.ts — 學生 CRUD（Admin 角色）
+
+| # | 測試案例 | 步驟 | 驗證 |
+|---|---------|------|------|
+| 3.1 | 建立學生 | 點擊「新增」→ 填寫表單 → 送出 | 列表出現新學生 |
+| 3.2 | 搜尋學生 | 在搜尋框輸入學生名稱 | 列表只顯示符合的結果 |
+| 3.3 | 編輯學生 | 點擊編輯 → 修改姓名 → 儲存 | 列表顯示新名稱 |
+| 3.4 | 停用學生 | 點擊停用 → 確認 | 學生狀態變為停用 |
+| 3.5 | 刪除學生 | 點擊刪除 → 確認 | 列表不再顯示該學生 |
+
+### 4. teachers.spec.ts — 教師 CRUD（Admin 角色）
+
+同 students，另加：
+
+| # | 測試案例 | 步驟 | 驗證 |
+|---|---------|------|------|
+| 4.6 | 教師總覽 | 進入教師總覽頁面 | 顯示合約數、預約數等統計 |
+| 4.7 | 教師詳情 | 點擊教師 → 進入詳情 | 顯示合約、預約、獎金區段 |
+
+### 5. courses.spec.ts — 課程 CRUD（Admin 角色）
+
+| # | 測試案例 | 步驟 | 驗證 |
+|---|---------|------|------|
+| 5.1 | 建立課程 | 填寫課程代碼 + 名稱 + 時長 → 送出 | 列表出現新課程 |
+| 5.2 | 修改課程 | 編輯課程名稱 → 儲存 | 列表顯示新名稱 |
+| 5.3 | 重複代碼 | 建立相同課程代碼 | 顯示錯誤「已存在」 |
+| 5.4 | 刪除課程 | 刪除 → 確認 | 列表不再顯示 |
+
+### 6. bookings.spec.ts — 預約流程（Admin 角色）
+
+| # | 測試案例 | 步驟 | 驗證 |
+|---|---------|------|------|
+| 6.1 | 建立預約 | 選擇學生 → 教師 → 課程 → 時段 → 送出 | 預約出現在列表 |
+| 6.2 | 確認預約 | 將預約狀態改為 confirmed | 狀態標籤變更 |
+| 6.3 | 取消預約 | 取消預約 | 狀態變為 cancelled |
+| 6.4 | 重複預約 | 建立相同時段預約 | 顯示衝突錯誤 |
+
+### 7. contracts.spec.ts — 合約管理（Admin 角色）
+
+| # | 測試案例 | 步驟 | 驗證 |
+|---|---------|------|------|
+| 7.1 | 建立學生合約 | 選擇學生 → 填寫堂數/金額 → 送出 | 合約出現在列表 |
+| 7.2 | 新增合約明細 | 進入合約 → 新增課程費率明細 | 明細列表顯示 |
+| 7.3 | 建立教師合約 | 選擇教師 → 填寫合約資訊 → 送出 | 合約出現在列表 |
+| 7.4 | 修改合約 | 編輯合約狀態 → 儲存 | 狀態更新 |
+
+### 8. employees.spec.ts — 員工管理（Admin 角色）
+
+| # | 測試案例 | 步驟 | 驗證 |
+|---|---------|------|------|
+| 8.1 | 建立員工 | 填寫員工資料 → 送出 | 列表出現新員工 |
+| 8.2 | 變更角色 | 編輯員工 → 選擇不同角色 → 儲存 | 角色欄位更新 |
+| 8.3 | 刪除員工 | 刪除 → 確認 | 列表不再顯示 |
+
+### 9. permissions.spec.ts — 權限即時生效（Admin 角色）
+
+這是最重要的測試，驗證後端的權限即時生效機制在前端也正確反映：
+
+| # | 測試案例 | 步驟 | 驗證 |
+|---|---------|------|------|
+| 9.1 | 角色變更即時生效 | Admin 建立 employee (intern) → 用該 employee 登入 → Admin 將其改為 admin 角色 → employee **不重新登入** → 重新整理頁面 | 側邊欄出現「帳號管理」「角色權限」 |
+| 9.2 | 權限收回即時生效 | 接續 9.1 → Admin 將角色改回 employee → employee 重新整理 | 側邊欄不再顯示「帳號管理」「角色權限」 |
+| 9.3 | 頁面存取被拒 | Student 角色直接存取 /students | 顯示權限不足或導向其他頁面 |
+
+---
+
+## 執行方式
+
+```bash
+# 前置：確保 Docker stack 運行中
+docker compose up -d
+
+# 跑全部測試
+cd frontend-dennis
+npx playwright test
+
+# 跑特定測試
+npx playwright test e2e/auth.spec.ts
+
+# 用 UI 模式除錯
+npx playwright test --ui
+
+# 只跑某個角色的測試
+npx playwright test --project=admin
+
+# 看報告
+npx playwright show-report
+```
+
+## 優先順序
+
+| 優先級 | 測試檔案 | 理由 |
+|--------|---------|------|
+| P0 | auth.spec.ts | 登入是所有流程的基礎 |
+| P0 | navigation.spec.ts | 驗證權限系統在前端正確反映 |
+| P1 | permissions.spec.ts | 驗證角色變更即時生效（核心功能） |
+| P1 | students.spec.ts | 最常用的 CRUD 流程 |
+| P1 | bookings.spec.ts | 最複雜的業務流程 |
+| P2 | courses.spec.ts | 基礎 CRUD |
+| P2 | teachers.spec.ts | CRUD + 總覽 |
+| P2 | contracts.spec.ts | 合約管理 |
+| P3 | employees.spec.ts | 員工管理 |
+
+## 注意事項
+
+1. **測試資料隔離**：每個 spec 檔案建立自己的測試資料，測試結束後清除（`afterAll`）
+2. **避免互相依賴**：各 spec 可獨立執行，不依賴其他測試的資料
+3. **等待策略**：用 `waitForResponse` 或 `waitForSelector` 取代固定 `sleep`
+4. **失敗截圖**：失敗時自動截圖存到 `test-results/`，方便除錯
+5. **CI 整合**：未來可加入 GitHub Actions，在 PR 時自動跑 E2E 測試

--- a/frontend-dennis/src/app/forgot-password/page.tsx
+++ b/frontend-dennis/src/app/forgot-password/page.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { authApi } from '@/lib/api/auth'
+
+export default function ForgotPasswordPage() {
+    const [email, setEmail] = useState('')
+    const [loading, setLoading] = useState(false)
+    const [sent, setSent] = useState(false)
+    const [error, setError] = useState('')
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault()
+        setError('')
+        setLoading(true)
+
+        const { error } = await authApi.requestPasswordReset(email)
+        if (error) {
+            setError(error.message)
+        } else {
+            setSent(true)
+        }
+
+        setLoading(false)
+    }
+
+    return (
+        <div className="min-h-screen flex items-center justify-center p-4">
+            <div className="card w-full max-w-md">
+                <h1 className="text-2xl font-bold text-center mb-2">重設密碼</h1>
+                <p className="text-center text-sm text-gray-500 mb-6">
+                    輸入您的 Email，我們將寄送重設密碼連結
+                </p>
+
+                {sent ? (
+                    <div className="text-center">
+                        <div className="bg-green-50 text-green-700 p-4 rounded-lg mb-6 text-sm border border-green-200">
+                            如果該 Email 已註冊，您將收到重設密碼郵件。請檢查您的信箱（含垃圾郵件資料夾）。
+                        </div>
+                        <Link
+                            href="/login"
+                            className="btn-primary inline-block"
+                        >
+                            返回登入
+                        </Link>
+                    </div>
+                ) : (
+                    <>
+                        {error && (
+                            <div className="bg-red-50 text-red-600 p-3 rounded-lg mb-4 text-sm">
+                                {error}
+                            </div>
+                        )}
+
+                        <form onSubmit={handleSubmit} className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">
+                                    Email
+                                </label>
+                                <input
+                                    type="email"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    className="input-field"
+                                    placeholder="your@email.com"
+                                    required
+                                />
+                            </div>
+
+                            <button
+                                type="submit"
+                                disabled={loading}
+                                className="btn-primary w-full disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {loading ? '發送中...' : '發送重設連結'}
+                            </button>
+                        </form>
+
+                        <p className="text-center text-sm text-gray-500 mt-6">
+                            <Link href="/login" className="text-primary-600 hover:underline">
+                                返回登入
+                            </Link>
+                        </p>
+                    </>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend-dennis/src/app/login/page.tsx
+++ b/frontend-dennis/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
 import { useAuth } from '@/lib/hooks/useAuth'
 import { lineApi } from '@/lib/api/line'
 
@@ -113,6 +114,12 @@ function LoginForm() {
         >
           {loading ? '登入中...' : '登入'}
         </button>
+
+        <div className="text-right mt-2">
+          <Link href="/forgot-password" className="text-sm text-primary-600 hover:underline">
+            忘記密碼？
+          </Link>
+        </div>
       </form>
 
       <div className="relative my-6">

--- a/frontend-dennis/src/lib/api/accounts.ts
+++ b/frontend-dennis/src/lib/api/accounts.ts
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiGet, apiPost, apiPut, apiDelete, qs } from './client'
 
 export interface AccountInfo {
   id: string
@@ -57,147 +57,33 @@ export interface UserPageOverride {
 }
 
 export const accountsApi = {
-  async list(params: {
-    page?: number
-    per_page?: number
-    role?: string
-    search?: string
-  }): Promise<{ data: AccountListResponse | null; error: any }> {
-    try {
-      const query = new URLSearchParams()
-      if (params.page) query.set('page', String(params.page))
-      if (params.per_page) query.set('per_page', String(params.per_page))
-      if (params.role) query.set('role', params.role)
-      if (params.search) query.set('search', params.search)
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/users/?${query.toString()}`)
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '取得帳號列表失敗' } }
-      }
-      const data = await response.json()
-      return { data, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '取得帳號列表失敗' } }
-    }
-  },
+  list: (params: { page?: number; per_page?: number; role?: string; search?: string }) =>
+    apiGet<AccountListResponse>(`/api/v1/users/${qs(params)}`, '取得帳號列表失敗', { extractData: false }),
 
-  async update(userId: string, data: AccountUpdateData): Promise<{ data: any; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/users/${userId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '更新帳號失敗' } }
-      }
-      const result = await response.json()
-      return { data: result, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '更新帳號失敗' } }
-    }
-  },
+  update: (userId: string, data: AccountUpdateData) =>
+    apiPut(`/api/v1/users/${userId}`, data, '更新帳號失敗', { extractData: false }),
 
-  async deactivate(userId: string): Promise<{ data: any; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/users/${userId}`, {
-        method: 'DELETE',
-      })
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '停用帳號失敗' } }
-      }
-      const result = await response.json()
-      return { data: result, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '停用帳號失敗' } }
-    }
-  },
+  deactivate: (userId: string) =>
+    apiDelete(`/api/v1/users/${userId}`, '停用帳號失敗'),
 
   // ========== Roles ==========
 
-  async getRoles(): Promise<{ data: RoleInfo[] | null; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/roles`)
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '取得角色列表失敗' } }
-      }
-      const result = await response.json()
-      return { data: result.data || [], error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '取得角色列表失敗' } }
-    }
-  },
+  getRoles: () =>
+    apiGet<RoleInfo[]>('/api/v1/roles', '取得角色列表失敗'),
 
-  async createRole(data: { key: string; name: string; description?: string }): Promise<{ data: any; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/roles`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '建立角色失敗' } }
-      }
-      const result = await response.json()
-      return { data: result, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '建立角色失敗' } }
-    }
-  },
+  createRole: (data: { key: string; name: string; description?: string }) =>
+    apiPost('/api/v1/roles', data, '建立角色失敗', { extractData: false }),
 
-  async updateRole(roleId: string, data: { name?: string; description?: string }): Promise<{ data: any; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/roles/${roleId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '更新角色失敗' } }
-      }
-      const result = await response.json()
-      return { data: result, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '更新角色失敗' } }
-    }
-  },
+  updateRole: (roleId: string, data: { name?: string; description?: string }) =>
+    apiPut(`/api/v1/roles/${roleId}`, data, '更新角色失敗', { extractData: false }),
 
-  async deleteRole(roleId: string): Promise<{ data: any; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/roles/${roleId}`, {
-        method: 'DELETE',
-      })
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '刪除角色失敗' } }
-      }
-      const result = await response.json()
-      return { data: result, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '刪除角色失敗' } }
-    }
-  },
+  deleteRole: (roleId: string) =>
+    apiDelete(`/api/v1/roles/${roleId}`, '刪除角色失敗'),
 
   // ========== Permission wrappers ==========
 
-  async getAllPages(): Promise<{ data: PageInfo[] | null; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/pages?per_page=200`)
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '取得頁面列表失敗' } }
-      }
-      const result = await response.json()
-      return { data: result.data || [], error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '取得頁面列表失敗' } }
-    }
-  },
+  getAllPages: () =>
+    apiGet<PageInfo[]>('/api/v1/pages?per_page=200', '取得頁面列表失敗'),
 
   async getRolePages(roleId: string): Promise<{ data: PageInfo[] | null; error: any }> {
     try {
@@ -213,23 +99,8 @@ export const accountsApi = {
     }
   },
 
-  async setRolePages(roleId: string, pageIds: string[]): Promise<{ data: any; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/role-pages`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ role_id: roleId, page_ids: pageIds }),
-      })
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '設定角色頁面失敗' } }
-      }
-      const result = await response.json()
-      return { data: result, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '設定角色頁面失敗' } }
-    }
-  },
+  setRolePages: (roleId: string, pageIds: string[]) =>
+    apiPut('/api/v1/role-pages', { role_id: roleId, page_ids: pageIds }, '設定角色頁面失敗', { extractData: false }),
 
   async getUserOverrides(userId: string): Promise<{ data: UserPageOverride[] | null; error: any }> {
     try {
@@ -245,24 +116,9 @@ export const accountsApi = {
     }
   },
 
-  async setUserOverrides(
+  setUserOverrides: (
     userId: string,
     overrides: { page_id: string; access_type: 'grant' | 'revoke' }[]
-  ): Promise<{ data: any; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/user-pages/${userId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ overrides }),
-      })
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '設定用戶覆寫失敗' } }
-      }
-      const result = await response.json()
-      return { data: result, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '設定用戶覆寫失敗' } }
-    }
-  },
+  ) =>
+    apiPut(`/api/v1/user-pages/${userId}`, { overrides }, '設定用戶覆寫失敗', { extractData: false }),
 }

--- a/frontend-dennis/src/lib/api/auth.ts
+++ b/frontend-dennis/src/lib/api/auth.ts
@@ -137,4 +137,7 @@ export const authApi = {
             current_password: currentPassword,
             new_password: newPassword,
         }, '密碼變更失敗'),
+
+    requestPasswordReset: (email: string) =>
+        apiAction('POST', '/api/v1/auth/password/reset', { email }, '發送重設密碼郵件失敗'),
 }

--- a/frontend-dennis/src/lib/api/auth.ts
+++ b/frontend-dennis/src/lib/api/auth.ts
@@ -2,8 +2,8 @@
 // This avoids CORS issues with the Supabase client
 
 import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiAction } from './client'
 
 interface AuthResponse {
     success: boolean
@@ -132,26 +132,9 @@ export const authApi = {
         }
     },
 
-    async changePassword(currentPassword: string, newPassword: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/auth/password/change`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    current_password: currentPassword,
-                    new_password: newPassword,
-                }),
-            })
-
-            const result = await response.json()
-
-            if (!response.ok || !result.success) {
-                return { success: false, error: { message: result.detail || result.message || '密碼變更失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    changePassword: (currentPassword: string, newPassword: string) =>
+        apiAction('POST', '/api/v1/auth/password/change', {
+            current_password: currentPassword,
+            new_password: newPassword,
+        }, '密碼變更失敗'),
 }

--- a/frontend-dennis/src/lib/api/bookings.ts
+++ b/frontend-dennis/src/lib/api/bookings.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiPut, apiAction, apiDelete, qs } from './client'
 
 export type BookingStatus = 'pending' | 'confirmed' | 'completed' | 'cancelled'
 
@@ -189,17 +187,8 @@ export interface SlotAvailabilityResponse {
     blocks: TimeBlock[]
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const bookingsApi = {
-    async list(params?: {
+    list: (params?: {
         page?: number
         per_page?: number
         search?: string
@@ -209,449 +198,72 @@ export const bookingsApi = {
         course_id?: string
         date_from?: string
         date_to?: string
-    }): Promise<{ data: BookingListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.search) queryParams.set('search', params.search)
-            if (params?.booking_status) queryParams.set('booking_status', params.booking_status)
-            if (params?.student_id) queryParams.set('student_id', params.student_id)
-            if (params?.teacher_id) queryParams.set('teacher_id', params.teacher_id)
-            if (params?.course_id) queryParams.set('course_id', params.course_id)
-            if (params?.date_from) queryParams.set('date_from', params.date_from)
-            if (params?.date_to) queryParams.set('date_to', params.date_to)
+    }) =>
+        apiGet<BookingListResponse>(`/api/v1/bookings${qs(params || {})}`, '取得預約列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/bookings${queryParams.toString() ? '?' + queryParams.toString() : ''}`
+    get: (bookingId: string) =>
+        apiGet<Booking>(`/api/v1/bookings/${bookingId}`, '取得預約失敗'),
 
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
+    create: (data: CreateBookingData) =>
+        apiPost<Booking>('/api/v1/bookings', data, '建立預約失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得預約列表失敗' } }
-            }
+    update: (bookingId: string, data: UpdateBookingData) =>
+        apiPut<Booking>(`/api/v1/bookings/${bookingId}`, data, '更新預約失敗'),
 
-            const result: BookingListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async get(bookingId: string): Promise<{ data: Booking | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/${bookingId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得預約失敗' } }
-            }
-
-            const result: BookingResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async create(data: CreateBookingData): Promise<{ data: Booking | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '建立預約失敗' } }
-            }
-
-            const result: BookingResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async update(bookingId: string, data: UpdateBookingData): Promise<{ data: Booking | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/${bookingId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新預約失敗' } }
-            }
-
-            const result: BookingResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(bookingId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/${bookingId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '刪除預約失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (bookingId: string) =>
+        apiDelete(`/api/v1/bookings/${bookingId}`, '刪除預約失敗'),
 
     // 批次操作 API
-    async createBatch(data: BatchCreateData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/batch`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
+    createBatch: (data: BatchCreateData) =>
+        apiAction('POST', '/api/v1/bookings/batch', data, '批次建立預約失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次建立預約失敗' } }
-            }
+    updateByIds: (data: BatchUpdateByIdsData) =>
+        apiAction('POST', '/api/v1/bookings/batch-by-ids/update', data, '批次更新預約失敗'),
 
-            const result = await response.json()
-            if (result.success === false) {
-                return { success: false, message: result.message, error: { message: result.message || '批次建立預約失敗' } }
-            }
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    deleteByIds: (data: BatchDeleteByIdsData) =>
+        apiAction('POST', '/api/v1/bookings/batch-by-ids/delete', data, '批次刪除預約失敗'),
 
-    async updateByIds(data: BatchUpdateByIdsData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/batch-by-ids/update`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
+    updateBatch: (data: BatchUpdateData) =>
+        apiAction('PUT', '/api/v1/bookings/batch', data, '批次更新預約失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次更新預約失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async deleteByIds(data: BatchDeleteByIdsData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/batch-by-ids/delete`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次刪除預約失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async updateBatch(data: BatchUpdateData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/batch`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次更新預約失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async deleteBatch(data: BatchDeleteData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/batch`, {
-                method: 'DELETE',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次刪除預約失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    deleteBatch: (data: BatchDeleteData) =>
+        apiAction('DELETE', '/api/v1/bookings/batch', data, '批次刪除預約失敗'),
 
     // 取得下拉選單選項
-    async getStudentOptions(): Promise<{ data: StudentOption[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/options/students`, {
-                method: 'GET',
-            })
+    getStudentOptions: () =>
+        apiGet<StudentOption[]>('/api/v1/bookings/options/students', '取得學生選項失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得學生選項失敗' } }
-            }
+    getTeacherOptions: (params?: { student_id?: string; course_id?: string }) =>
+        apiGet<TeacherOption[]>(`/api/v1/bookings/options/teachers${qs(params || {})}`, '取得教師選項失敗'),
 
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getOverlappingCourseOptions: (studentId: string, teacherId: string) =>
+        apiGet<CourseOption[]>(`/api/v1/bookings/options/overlapping-courses${qs({ student_id: studentId, teacher_id: teacherId })}`, '取得交集課程選項失敗'),
 
-    async getTeacherOptions(params?: { student_id?: string, course_id?: string }): Promise<{ data: TeacherOption[] | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.student_id) queryParams.set('student_id', params.student_id)
-            if (params?.course_id) queryParams.set('course_id', params.course_id)
+    getCourseOptions: () =>
+        apiGet<CourseOption[]>('/api/v1/bookings/options/courses', '取得課程選項失敗'),
 
-            const url = `${API_BASE_URL}/api/v1/bookings/options/teachers${queryParams.toString() ? '?' + queryParams.toString() : ''}`
+    getStudentContractOptions: (studentId: string) =>
+        apiGet<StudentContractOption[]>(`/api/v1/bookings/options/student-contracts/${studentId}`, '取得學生合約選項失敗'),
 
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
+    getTeacherContractOptions: (teacherId: string) =>
+        apiGet<TeacherContractOption[]>(`/api/v1/bookings/options/teacher-contracts/${teacherId}`, '取得教師合約選項失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-
-    async getOverlappingCourseOptions(studentId: string, teacherId: string): Promise<{ data: CourseOption[] | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            queryParams.set('student_id', studentId)
-            queryParams.set('teacher_id', teacherId)
-
-            const url = `${API_BASE_URL}/api/v1/bookings/options/overlapping-courses?${queryParams.toString()}`
-
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得交集課程選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getCourseOptions(): Promise<{ data: CourseOption[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/options/courses`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得課程選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getStudentContractOptions(studentId: string): Promise<{ data: StudentContractOption[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/options/student-contracts/${studentId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得學生合約選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getTeacherContractOptions(teacherId: string): Promise<{ data: TeacherContractOption[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/options/teacher-contracts/${teacherId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師合約選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getTeacherSlotOptions(teacherId: string, dateFrom?: string, dateTo?: string): Promise<{ data: TeacherSlotOption[] | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (dateFrom) queryParams.set('date_from', dateFrom)
-            if (dateTo) queryParams.set('date_to', dateTo)
-
-            const url = `${API_BASE_URL}/api/v1/bookings/options/teacher-slots/${teacherId}${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師時段選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getTeacherSlotOptions: (teacherId: string, dateFrom?: string, dateTo?: string) =>
+        apiGet<TeacherSlotOption[]>(`/api/v1/bookings/options/teacher-slots/${teacherId}${qs({ date_from: dateFrom, date_to: dateTo })}`, '取得教師時段選項失敗'),
 
     // 取得當前學生的資料（學生用）
-    async getMyStudentInfo(): Promise<{ data: StudentOption | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/my-student-info`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得學生資料失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getMyStudentInfo: () =>
+        apiGet<StudentOption>('/api/v1/bookings/my-student-info', '取得學生資料失敗'),
 
     // 取得時段的 30 分鐘區塊可用狀態
-    async getSlotAvailability(slotId: string): Promise<{ data: SlotAvailabilityResponse | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/slot-availability/${slotId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得時段可用狀態失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getSlotAvailability: (slotId: string) =>
+        apiGet<SlotAvailabilityResponse>(`/api/v1/bookings/slot-availability/${slotId}`, '取得時段可用狀態失敗'),
 
     // 取得可用代課教師選項
-    async getSubstituteTeacherOptions(bookingId: string): Promise<{ data: SubstituteTeacherOption[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/options/substitute-teachers?booking_id=${encodeURIComponent(bookingId)}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得代課教師選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getSubstituteTeacherOptions: (bookingId: string) =>
+        apiGet<SubstituteTeacherOption[]>(`/api/v1/bookings/options/substitute-teachers${qs({ booking_id: bookingId })}`, '取得代課教師選項失敗'),
 
     // 取得當前學生的合約（學生用）
-    async getMyContracts(): Promise<{ data: StudentContractOption[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/bookings/my-contracts`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得學生合約選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getMyContracts: () =>
+        apiGet<StudentContractOption[]>('/api/v1/bookings/my-contracts', '取得學生合約選項失敗'),
 }

--- a/frontend-dennis/src/lib/api/client.ts
+++ b/frontend-dennis/src/lib/api/client.ts
@@ -1,0 +1,166 @@
+import { fetchWithAuth } from './fetchWithAuth'
+import { API_BASE_URL } from './config'
+import type { ApiError, ApiResult, ApiActionResult, ApiBlobResult } from './types'
+
+// ============================================================
+// Error parsing
+// ============================================================
+
+function parseErrorDetail(detail: unknown): string {
+  if (typeof detail === 'string') return detail
+  if (Array.isArray(detail) && detail.length > 0) {
+    const msg = detail[0]?.msg || ''
+    return msg.replace(/^Value error,\s*/, '')
+  }
+  return ''
+}
+
+function toApiError(status: number, body: Record<string, unknown>, fallback: string): ApiError {
+  return {
+    message: parseErrorDetail(body.detail) || (body.message as string) || fallback,
+    code: (body.error_code as string) || 'UNKNOWN',
+    status,
+  }
+}
+
+const NETWORK_ERROR: ApiError = { message: '網路錯誤，請稍後再試', code: 'NETWORK_ERROR', status: 0 }
+
+// ============================================================
+// Core helpers
+// ============================================================
+
+/**
+ * GET 請求，回傳 { data, error }
+ * data 預設取 response body 的 .data 欄位；若 extractData=false 則回傳整個 body
+ */
+export async function apiGet<T>(
+  path: string,
+  fallback = '操作失敗',
+  { extractData = true }: { extractData?: boolean } = {},
+): Promise<ApiResult<T>> {
+  try {
+    const res = await fetchWithAuth(`${API_BASE_URL}${path}`)
+    const body = await res.json()
+    if (!res.ok) return { data: null, error: toApiError(res.status, body, fallback) }
+    return { data: (extractData ? body.data : body) as T, error: null }
+  } catch {
+    return { data: null, error: NETWORK_ERROR }
+  }
+}
+
+/** POST 請求，回傳 { data, error } */
+export async function apiPost<T>(
+  path: string,
+  payload?: unknown,
+  fallback = '操作失敗',
+  { extractData = true }: { extractData?: boolean } = {},
+): Promise<ApiResult<T>> {
+  try {
+    const res = await fetchWithAuth(`${API_BASE_URL}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload !== undefined ? JSON.stringify(payload) : undefined,
+    })
+    const body = await res.json()
+    if (!res.ok) return { data: null, error: toApiError(res.status, body, fallback) }
+    return { data: (extractData ? body.data : body) as T, error: null }
+  } catch {
+    return { data: null, error: NETWORK_ERROR }
+  }
+}
+
+/** PUT 請求，回傳 { data, error } */
+export async function apiPut<T>(
+  path: string,
+  payload?: unknown,
+  fallback = '操作失敗',
+  { extractData = true }: { extractData?: boolean } = {},
+): Promise<ApiResult<T>> {
+  try {
+    const res = await fetchWithAuth(`${API_BASE_URL}${path}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload !== undefined ? JSON.stringify(payload) : undefined,
+    })
+    const body = await res.json()
+    if (!res.ok) return { data: null, error: toApiError(res.status, body, fallback) }
+    return { data: (extractData ? body.data : body) as T, error: null }
+  } catch {
+    return { data: null, error: NETWORK_ERROR }
+  }
+}
+
+/** DELETE 請求，回傳 { success, error } */
+export async function apiDelete(
+  path: string,
+  fallback = '刪除失敗',
+  payload?: unknown,
+): Promise<ApiActionResult> {
+  try {
+    const options: RequestInit = { method: 'DELETE' }
+    if (payload !== undefined) {
+      options.headers = { 'Content-Type': 'application/json' }
+      options.body = JSON.stringify(payload)
+    }
+    const res = await fetchWithAuth(`${API_BASE_URL}${path}`, options)
+    const body = await res.json()
+    if (!res.ok) return { success: false, message: '', error: toApiError(res.status, body, fallback) }
+    return { success: true, message: (body.message as string) || '操作成功', error: null }
+  } catch {
+    return { success: false, message: '', error: NETWORK_ERROR }
+  }
+}
+
+/** POST/PUT 只關心成功與否，不需要 data（例如 confirm upload） */
+export async function apiAction(
+  method: 'POST' | 'PUT' | 'DELETE',
+  path: string,
+  payload?: unknown,
+  fallback = '操作失敗',
+): Promise<ApiActionResult> {
+  try {
+    const options: RequestInit = { method }
+    if (payload !== undefined) {
+      options.headers = { 'Content-Type': 'application/json' }
+      options.body = JSON.stringify(payload)
+    }
+    const res = await fetchWithAuth(`${API_BASE_URL}${path}`, options)
+    const body = await res.json()
+    if (!res.ok) return { success: false, message: '', error: toApiError(res.status, body, fallback) }
+    return { success: true, message: (body.message as string) || '操作成功', error: null }
+  } catch {
+    return { success: false, message: '', error: NETWORK_ERROR }
+  }
+}
+
+/** Blob 下載（PDF / DOCX 等） */
+export async function apiBlob(
+  method: 'GET' | 'POST',
+  path: string,
+  payload?: unknown,
+  fallback = '下載失敗',
+): Promise<ApiBlobResult> {
+  try {
+    const options: RequestInit = { method }
+    if (payload !== undefined) {
+      options.headers = { 'Content-Type': 'application/json' }
+      options.body = JSON.stringify(payload)
+    }
+    const res = await fetchWithAuth(`${API_BASE_URL}${path}`, options)
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      return { blob: null, error: toApiError(res.status, body, fallback) }
+    }
+    const blob = await res.blob()
+    return { blob, error: null }
+  } catch {
+    return { blob: null, error: NETWORK_ERROR }
+  }
+}
+
+/** 建立 query string，自動忽略 undefined/null 值 */
+export function qs(params: Record<string, unknown>): string {
+  const entries = Object.entries(params).filter(([, v]) => v != null && v !== '')
+  if (!entries.length) return ''
+  return '?' + new URLSearchParams(entries.map(([k, v]) => [k, String(v)])).toString()
+}

--- a/frontend-dennis/src/lib/api/config.ts
+++ b/frontend-dennis/src/lib/api/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'

--- a/frontend-dennis/src/lib/api/contractAddendums.ts
+++ b/frontend-dennis/src/lib/api/contractAddendums.ts
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiGet, apiPost, apiPut, apiDelete } from './client'
 
 export type AddendumStatus = 'pending' | 'active' | 'expired' | 'terminated'
 export type ContractType = 'student' | 'teacher'
@@ -38,76 +38,31 @@ function contractBasePath(contractType: ContractType): string {
 }
 
 export const contractAddendumsApi = {
-    async list(contractType: ContractType, contractId: string): Promise<{ data: ContractAddendum[], error: any }> {
-        try {
-            const base = contractBasePath(contractType)
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/${base}/${contractId}/addendums`, {
-                method: 'GET',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得附約列表失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    list: (contractType: ContractType, contractId: string) =>
+        apiGet<ContractAddendum[]>(
+            `/api/v1/${contractBasePath(contractType)}/${contractId}/addendums`,
+            '取得附約列表失敗',
+        ),
 
-    async create(contractType: ContractType, contractId: string, data: CreateAddendumData): Promise<{ data: ContractAddendum | null, error: any }> {
-        try {
-            const base = contractBasePath(contractType)
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/${base}/${contractId}/addendums`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '建立附約失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    create: (contractType: ContractType, contractId: string, data: CreateAddendumData) =>
+        apiPost<ContractAddendum>(
+            `/api/v1/${contractBasePath(contractType)}/${contractId}/addendums`,
+            data,
+            '建立附約失敗',
+        ),
 
-    async update(contractType: ContractType, contractId: string, addendumId: string, data: UpdateAddendumData): Promise<{ data: ContractAddendum | null, error: any }> {
-        try {
-            const base = contractBasePath(contractType)
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/${base}/${contractId}/addendums/${addendumId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '更新附約失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    update: (contractType: ContractType, contractId: string, addendumId: string, data: UpdateAddendumData) =>
+        apiPut<ContractAddendum>(
+            `/api/v1/${contractBasePath(contractType)}/${contractId}/addendums/${addendumId}`,
+            data,
+            '更新附約失敗',
+        ),
 
-    async delete(contractType: ContractType, contractId: string, addendumId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const base = contractBasePath(contractType)
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/${base}/${contractId}/addendums/${addendumId}`, {
-                method: 'DELETE',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '刪除附約失敗' } }
-            }
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (contractType: ContractType, contractId: string, addendumId: string) =>
+        apiDelete(
+            `/api/v1/${contractBasePath(contractType)}/${contractId}/addendums/${addendumId}`,
+            '刪除附約失敗',
+        ),
 
     async generatePdf(contractType: ContractType, contractId: string, addendumId: string): Promise<{ success: boolean, error: any }> {
         try {

--- a/frontend-dennis/src/lib/api/courses.ts
+++ b/frontend-dennis/src/lib/api/courses.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiPut, apiDelete, qs } from './client'
 
 export interface Course {
     id: string
@@ -22,12 +20,6 @@ export interface CourseListResponse {
     total_pages: number
 }
 
-export interface CourseResponse {
-    success: boolean
-    message: string
-    data?: Course
-}
-
 export interface CreateCourseData {
     course_code: string
     course_name: string
@@ -45,113 +37,18 @@ export interface UpdateCourseData {
 }
 
 export const coursesApi = {
-    async list(params?: {
-        page?: number
-        per_page?: number
-        search?: string
-        is_active?: boolean
-    }): Promise<{ data: CourseListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.search) queryParams.set('search', params.search)
-            if (params?.is_active !== undefined) queryParams.set('is_active', params.is_active.toString())
+    list: (params?: { page?: number; per_page?: number; search?: string; is_active?: boolean }) =>
+        apiGet<CourseListResponse>(`/api/v1/courses${qs(params || {})}`, '取得課程列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/courses${queryParams.toString() ? '?' + queryParams.toString() : ''}`
+    get: (courseId: string) =>
+        apiGet<Course>(`/api/v1/courses/${courseId}`, '取得課程失敗'),
 
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
+    create: (data: CreateCourseData) =>
+        apiPost<Course>('/api/v1/courses', data, '建立課程失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '取得課程列表失敗' } }
-            }
+    update: (courseId: string, data: UpdateCourseData) =>
+        apiPut<Course>(`/api/v1/courses/${courseId}`, data, '更新課程失敗'),
 
-            const result: CourseListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async get(courseId: string): Promise<{ data: Course | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/courses/${courseId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '取得課程失敗' } }
-            }
-
-            const result: CourseResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async create(data: CreateCourseData): Promise<{ data: Course | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/courses`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '建立課程失敗' } }
-            }
-
-            const result: CourseResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async update(courseId: string, data: UpdateCourseData): Promise<{ data: Course | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/courses/${courseId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '更新課程失敗' } }
-            }
-
-            const result: CourseResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(courseId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/courses/${courseId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '刪除課程失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (courseId: string) =>
+        apiDelete(`/api/v1/courses/${courseId}`, '刪除課程失敗'),
 }

--- a/frontend-dennis/src/lib/api/employees.ts
+++ b/frontend-dennis/src/lib/api/employees.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiPut, apiDelete, qs } from './client'
 
 export type EmployeeType = 'admin' | 'full_time' | 'part_time' | 'intern'
 
@@ -62,92 +60,18 @@ export interface EmployeeListResponse {
 }
 
 export const employeesApi = {
-    async list(params?: {
-        page?: number
-        per_page?: number
-        search?: string
-        is_active?: boolean
-        employee_type?: string
-    }): Promise<{ data: EmployeeListResponse | null, error: any }> {
-        try {
-            const searchParams = new URLSearchParams()
-            if (params?.page) searchParams.set('page', String(params.page))
-            if (params?.per_page) searchParams.set('per_page', String(params.per_page))
-            if (params?.search) searchParams.set('search', params.search)
-            if (params?.is_active !== undefined) searchParams.set('is_active', String(params.is_active))
-            if (params?.employee_type) searchParams.set('employee_type', params.employee_type)
+    list: (params?: { page?: number; per_page?: number; search?: string; is_active?: boolean; employee_type?: string }) =>
+        apiGet<EmployeeListResponse>(`/api/v1/employees${qs(params || {})}`, '取得員工列表失敗', { extractData: false }),
 
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/employees?${searchParams}`)
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '取得員工列表失敗' } }
-            }
-            const result = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    create: (data: CreateEmployeeData) =>
+        apiPost<Employee>('/api/v1/employees', data, '建立員工失敗'),
 
-    async create(data: CreateEmployeeData): Promise<{ data: Employee | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/employees`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '建立員工失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    update: (id: string, data: UpdateEmployeeData) =>
+        apiPut<Employee>(`/api/v1/employees/${id}`, data, '更新員工失敗'),
 
-    async update(id: string, data: UpdateEmployeeData): Promise<{ data: Employee | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/employees/${id}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '更新員工失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (id: string) =>
+        apiDelete(`/api/v1/employees/${id}`, '刪除員工失敗'),
 
-    async listRoles(): Promise<{ data: Role[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/employees/roles`)
-            if (!response.ok) return { data: [], error: null }
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch {
-            return { data: [], error: null }
-        }
-    },
-
-    async delete(id: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/employees/${id}`, {
-                method: 'DELETE',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '刪除員工失敗' } }
-            }
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    listRoles: () =>
+        apiGet<Role[]>('/api/v1/employees/roles', '取得角色列表失敗'),
 }

--- a/frontend-dennis/src/lib/api/fetchWithAuth.ts
+++ b/frontend-dennis/src/lib/api/fetchWithAuth.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
 
 let refreshPromise: Promise<boolean> | null = null
 
@@ -10,8 +10,14 @@ async function refreshTokens(): Promise<boolean> {
     return response.ok
 }
 
-/** 從 401 response body 判斷登出原因 */
-function detectLogoutReason(detail: string): string {
+/** 從 401 response body 判斷登出原因（優先用 error_code，fallback 到中文字串比對） */
+function detectLogoutReason(body: Record<string, unknown>): string {
+    const code = body.error_code as string | undefined
+    if (code === 'AUTH_IDLE_TIMEOUT') return 'idle'
+    if (code === 'AUTH_SESSION_REPLACED') return 'replaced'
+    if (code) return 'expired'
+    // fallback: 舊格式相容
+    const detail = (body.detail || body.message || '') as string
     if (detail.includes('閒置超時')) return 'idle'
     if (detail.includes('其他裝置')) return 'replaced'
     return 'expired'
@@ -31,7 +37,7 @@ export async function fetchWithAuth(
         let reason = 'expired'
         try {
             const errBody = await errClone.json()
-            reason = detectLogoutReason(errBody.detail || '')
+            reason = detectLogoutReason(errBody)
         } catch { /* ignore parse errors */ }
 
         // Mutex: 同一時間只有一個 refresh 請求

--- a/frontend-dennis/src/lib/api/googleDrive.ts
+++ b/frontend-dennis/src/lib/api/googleDrive.ts
@@ -1,12 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
-
-function parseErrorDetail(detail: any): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail)) return detail.map(d => d.msg || d.message || JSON.stringify(d)).join(', ')
-    return JSON.stringify(detail)
-}
+import { apiGet, apiDelete, apiAction } from './client'
 
 export interface GoogleDriveStatus {
     is_linked: boolean
@@ -17,62 +9,15 @@ export interface GoogleDriveStatus {
 }
 
 export const googleDriveApi = {
-    async getStatus(): Promise<{ data: GoogleDriveStatus | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/google-drive/oauth/status`)
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得狀態失敗' } }
-            }
-            const result = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤' } }
-        }
-    },
+    getStatus: () =>
+        apiGet<GoogleDriveStatus>('/api/v1/google-drive/oauth/status', '取得狀態失敗', { extractData: false }),
 
-    async getAuthorizeUrl(): Promise<{ data: { authorize_url: string } | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/google-drive/oauth/authorize`)
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得授權 URL 失敗' } }
-            }
-            const result = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤' } }
-        }
-    },
+    getAuthorizeUrl: () =>
+        apiGet<{ authorize_url: string }>('/api/v1/google-drive/oauth/authorize', '取得授權 URL 失敗', { extractData: false }),
 
-    async unlink(): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/google-drive/oauth/unlink`, {
-                method: 'DELETE',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '解除綁定失敗' } }
-            }
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤' } }
-        }
-    },
+    unlink: () =>
+        apiDelete('/api/v1/google-drive/oauth/unlink', '解除綁定失敗'),
 
-    async updateFolder(folderId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(
-                `${API_BASE_URL}/api/v1/google-drive/folder?folder_id=${encodeURIComponent(folderId)}`,
-                { method: 'PUT' }
-            )
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '設定資料夾失敗' } }
-            }
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤' } }
-        }
-    },
+    updateFolder: (folderId: string) =>
+        apiAction('PUT', `/api/v1/google-drive/folder?folder_id=${encodeURIComponent(folderId)}`, undefined, '設定資料夾失敗'),
 }

--- a/frontend-dennis/src/lib/api/invites.ts
+++ b/frontend-dennis/src/lib/api/invites.ts
@@ -1,6 +1,5 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiPost } from './client'
 
 export interface GenerateInviteResponse {
     invite_url: string
@@ -12,38 +11,14 @@ export interface AcceptInviteResponse {
     message: string
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const invitesApi = {
-    async generate(entityType: 'student' | 'teacher' | 'employee', entityId: string, roleId?: string): Promise<{ data: GenerateInviteResponse | null, error: any }> {
-        try {
-            const body: any = { entity_type: entityType, entity_id: entityId }
-            if (roleId) body.role_id = roleId
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/invites/generate`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(body),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '產生邀請連結失敗' } }
-            }
-
-            const result: GenerateInviteResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
+    generate: (entityType: 'student' | 'teacher' | 'employee', entityId: string, roleId?: string) => {
+        const body: Record<string, unknown> = { entity_type: entityType, entity_id: entityId }
+        if (roleId) body.role_id = roleId
+        return apiPost<GenerateInviteResponse>('/api/v1/invites/generate', body, '產生邀請連結失敗', { extractData: false })
     },
 
+    /** accept 不需要 auth cookie（公開端點），直接用 fetch */
     async accept(token: string, password: string): Promise<{ data: AcceptInviteResponse | null, error: any }> {
         try {
             const response = await fetch(`${API_BASE_URL}/api/v1/invites/accept`, {
@@ -54,7 +29,11 @@ export const invitesApi = {
 
             if (!response.ok) {
                 const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '建立帳號失敗' } }
+                const detail = error.detail
+                const message = typeof detail === 'string' ? detail
+                    : Array.isArray(detail) && detail.length > 0 ? (detail[0]?.msg || '').replace(/^Value error,\s*/, '')
+                    : '建立帳號失敗'
+                return { data: null, error: { message } }
             }
 
             const result: AcceptInviteResponse = await response.json()

--- a/frontend-dennis/src/lib/api/leaveRecords.ts
+++ b/frontend-dennis/src/lib/api/leaveRecords.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, qs } from './client'
 
 export type LeaveStatus = 'pending' | 'approved' | 'rejected' | 'cancelled'
 
@@ -41,100 +39,19 @@ export interface LeaveRecordListResponse {
     total_pages: number
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const leaveRecordsApi = {
-    async create(data: { booking_id: string; reason: string }): Promise<{ data: LeaveRecord | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/leave-records`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '建立請假申請失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    create: (data: { booking_id: string; reason: string }) =>
+        apiPost<LeaveRecord>('/api/v1/leave-records', data, '建立請假申請失敗'),
 
-    async list(params?: { page?: number; per_page?: number; leave_status?: LeaveStatus }): Promise<{ data: LeaveRecordListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.leave_status) queryParams.set('leave_status', params.leave_status)
-            const url = `${API_BASE_URL}/api/v1/leave-records${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-            const response = await fetchWithAuth(url, { method: 'GET' })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得請假紀錄失敗' } }
-            }
-            const result: LeaveRecordListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    list: (params?: { page?: number; per_page?: number; leave_status?: LeaveStatus }) =>
+        apiGet<LeaveRecordListResponse>(`/api/v1/leave-records${qs(params || {})}`, '取得請假紀錄失敗', { extractData: false }),
 
-    async approve(leaveId: string): Promise<{ data: LeaveRecord | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/leave-records/${leaveId}/approve`, {
-                method: 'POST',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '核准請假失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    approve: (leaveId: string) =>
+        apiPost<LeaveRecord>(`/api/v1/leave-records/${leaveId}/approve`, undefined, '核准請假失敗'),
 
-    async reject(leaveId: string, rejection_reason: string): Promise<{ data: LeaveRecord | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/leave-records/${leaveId}/reject`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ rejection_reason }),
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '駁回請假失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    reject: (leaveId: string, rejection_reason: string) =>
+        apiPost<LeaveRecord>(`/api/v1/leave-records/${leaveId}/reject`, { rejection_reason }, '駁回請假失敗'),
 
-    async cancel(leaveId: string): Promise<{ data: LeaveRecord | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/leave-records/${leaveId}/cancel`, {
-                method: 'POST',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '撤回請假失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    cancel: (leaveId: string) =>
+        apiPost<LeaveRecord>(`/api/v1/leave-records/${leaveId}/cancel`, undefined, '撤回請假失敗'),
 }

--- a/frontend-dennis/src/lib/api/line.ts
+++ b/frontend-dennis/src/lib/api/line.ts
@@ -1,10 +1,9 @@
 import { fetchWithAuth } from './fetchWithAuth'
+import { API_BASE_URL } from './config'
 
 /**
  * Line 綁定 API
  */
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
 
 export interface LineBindingStatus {
   is_bound: boolean

--- a/frontend-dennis/src/lib/api/notifications.ts
+++ b/frontend-dennis/src/lib/api/notifications.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiAction } from './client'
 
 export interface NotificationPreferences {
     email_enabled: boolean
@@ -12,33 +10,9 @@ export interface NotificationPreferences {
 }
 
 export const notificationsApi = {
-    async getPreferences(): Promise<{ data: NotificationPreferences | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/notifications/preferences`)
-            if (!response.ok) {
-                return { data: null, error: { message: '取得通知設定失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data, error: null }
-        } catch {
-            return { data: null, error: { message: '網路錯誤' } }
-        }
-    },
+    getPreferences: () =>
+        apiGet<NotificationPreferences>('/api/v1/notifications/preferences', '取得通知設定失敗'),
 
-    async updatePreferences(data: NotificationPreferences): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/notifications/preferences`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-            if (!response.ok) {
-                const err = await response.json()
-                return { success: false, error: { message: err.detail || '更新失敗' } }
-            }
-            return { success: true, error: null }
-        } catch {
-            return { success: false, error: { message: '網路錯誤' } }
-        }
-    },
+    updatePreferences: (data: NotificationPreferences) =>
+        apiAction('PUT', '/api/v1/notifications/preferences', data, '更新失敗'),
 }

--- a/frontend-dennis/src/lib/api/permissions.ts
+++ b/frontend-dennis/src/lib/api/permissions.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet } from './client'
 
 export interface PageInfo {
   id: string
@@ -20,17 +18,6 @@ export interface MyPermissionsResponse {
 }
 
 export const permissionsApi = {
-  async getMyPermissions(): Promise<{ data: MyPermissionsResponse | null; error: any }> {
-    try {
-      const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/permissions/me`)
-      if (!response.ok) {
-        const err = await response.json()
-        return { data: null, error: { message: err.detail || '取得權限失敗' } }
-      }
-      const data = await response.json()
-      return { data, error: null }
-    } catch (e: any) {
-      return { data: null, error: { message: e.message || '取得權限失敗' } }
-    }
-  },
+  getMyPermissions: () =>
+    apiGet<MyPermissionsResponse>('/api/v1/permissions/me', '取得權限失敗', { extractData: false }),
 }

--- a/frontend-dennis/src/lib/api/studentContracts.ts
+++ b/frontend-dennis/src/lib/api/studentContracts.ts
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiGet, apiPost, apiPut, apiDelete, qs } from './client'
 
 export type ContractStatus = 'pending' | 'active' | 'expired' | 'terminated'
 export type DetailType = 'lesson_price' | 'discount' | 'compensation'
@@ -124,118 +124,28 @@ export interface CourseOption {
 }
 
 export const studentContractsApi = {
-    async list(params?: {
+    list: (params?: {
         page?: number
         per_page?: number
         search?: string
         contract_status?: ContractStatus
         student_id?: string
-    }): Promise<{ data: StudentContractListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.search) queryParams.set('search', params.search)
-            if (params?.contract_status) queryParams.set('contract_status', params.contract_status)
-            if (params?.student_id) queryParams.set('student_id', params.student_id)
+    }) =>
+        apiGet<StudentContractListResponse>(`/api/v1/student-contracts${qs(params || {})}`, '取得學生合約列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/student-contracts${queryParams.toString() ? '?' + queryParams.toString() : ''}`
+    get: (contractId: string) =>
+        apiGet<StudentContract>(`/api/v1/student-contracts/${contractId}`, '取得學生合約失敗'),
 
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
+    create: (data: CreateStudentContractData) =>
+        apiPost<StudentContract>('/api/v1/student-contracts', data, '建立學生合約失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '取得學生合約列表失敗' } }
-            }
+    update: (contractId: string, data: UpdateStudentContractData) =>
+        apiPut<StudentContract>(`/api/v1/student-contracts/${contractId}`, data, '更新學生合約失敗'),
 
-            const result: StudentContractListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (contractId: string) =>
+        apiDelete(`/api/v1/student-contracts/${contractId}`, '刪除學生合約失敗'),
 
-    async get(contractId: string): Promise<{ data: StudentContract | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '取得學生合約失敗' } }
-            }
-
-            const result: StudentContractResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async create(data: CreateStudentContractData): Promise<{ data: StudentContract | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '建立學生合約失敗' } }
-            }
-
-            const result: StudentContractResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async update(contractId: string, data: UpdateStudentContractData): Promise<{ data: StudentContract | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '更新學生合約失敗' } }
-            }
-
-            const result: StudentContractResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(contractId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '刪除學生合約失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
+    // Presigned URL upload flow — keep fetchWithAuth
     async uploadFile(contractId: string, file: File): Promise<{ data: StudentContract | null, error: any }> {
         try {
             const fileExt = file.name.split('.').pop()?.toLowerCase() || 'pdf'
@@ -283,12 +193,10 @@ export const studentContractsApi = {
 
     async generatePdf(contractId: string): Promise<{ success: boolean, error: any }> {
         try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/generate-docx`, {
-                method: 'GET',
-            })
+            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/generate-docx`)
             if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '產生合約文件失敗' } }
+                const err = await response.json()
+                return { success: false, error: { message: err.detail || '產生合約文件失敗' } }
             }
             const blob = await response.blob()
             const contentDisposition = response.headers.get('Content-Disposition')
@@ -306,199 +214,45 @@ export const studentContractsApi = {
             document.body.removeChild(a)
             window.URL.revokeObjectURL(url)
             return { success: true, error: null }
-        } catch (err) {
+        } catch {
             return { success: false, error: { message: '網路錯誤，請稍後再試' } }
         }
     },
 
     async downloadFile(contractId: string): Promise<{ url: string | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/download-url`, {
-                method: 'GET',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { url: null, error: { message: error.detail || '取得下載連結失敗' } }
-            }
-            const { download_url } = await response.json()
-            return { url: download_url, error: null }
-        } catch (err) {
-            return { url: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
+        const { data, error } = await apiGet<{ download_url: string }>(`/api/v1/student-contracts/${contractId}/download-url`, '取得下載連結失敗', { extractData: false })
+        if (error) return { url: null, error }
+        return { url: data!.download_url, error: null }
     },
 
-    async getStudentOptions(): Promise<{ data: StudentOption[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/options/students`, {
-                method: 'GET',
-            })
+    getStudentOptions: () =>
+        apiGet<StudentOption[]>('/api/v1/student-contracts/options/students', '取得學生選項失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得學生選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getCourseOptions(studentId?: string): Promise<{ data: CourseOption[], error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (studentId) queryParams.set('student_id', studentId)
-
-            const url = `${API_BASE_URL}/api/v1/student-contracts/options/courses${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得課程選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getCourseOptions: (studentId?: string) =>
+        apiGet<CourseOption[]>(`/api/v1/student-contracts/options/courses${qs({ student_id: studentId })}`, '取得課程選項失敗'),
 
     // ========== Details API ==========
 
-    async listDetails(contractId: string): Promise<{ data: StudentContractDetail[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/details`, {
-                method: 'GET',
-            })
+    listDetails: (contractId: string) =>
+        apiGet<StudentContractDetail[]>(`/api/v1/student-contracts/${contractId}/details`, '取得合約明細失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得合約明細失敗' } }
-            }
+    createDetail: (contractId: string, data: CreateDetailData) =>
+        apiPost<StudentContractDetail>(`/api/v1/student-contracts/${contractId}/details`, data, '新增合約明細失敗'),
 
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    updateDetail: (contractId: string, detailId: string, data: UpdateDetailData) =>
+        apiPut<StudentContractDetail>(`/api/v1/student-contracts/${contractId}/details/${detailId}`, data, '更新合約明細失敗'),
 
-    async createDetail(contractId: string, data: CreateDetailData): Promise<{ data: StudentContractDetail | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/details`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '新增合約明細失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async updateDetail(contractId: string, detailId: string, data: UpdateDetailData): Promise<{ data: StudentContractDetail | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/details/${detailId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '更新合約明細失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async deleteDetail(contractId: string, detailId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/details/${detailId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '刪除合約明細失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    deleteDetail: (contractId: string, detailId: string) =>
+        apiDelete(`/api/v1/student-contracts/${contractId}/details/${detailId}`, '刪除合約明細失敗'),
 
     // ========== Leave Records API ==========
 
-    async listLeaveRecords(contractId: string): Promise<{ data: StudentContractLeaveRecord[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/leave-records`, {
-                method: 'GET',
-            })
+    listLeaveRecords: (contractId: string) =>
+        apiGet<StudentContractLeaveRecord[]>(`/api/v1/student-contracts/${contractId}/leave-records`, '取得請假紀錄失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得請假紀錄失敗' } }
-            }
+    createLeaveRecord: (contractId: string, data: CreateLeaveRecordData) =>
+        apiPost<StudentContractLeaveRecord>(`/api/v1/student-contracts/${contractId}/leave-records`, data, '新增請假紀錄失敗'),
 
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async createLeaveRecord(contractId: string, data: CreateLeaveRecordData): Promise<{ data: StudentContractLeaveRecord | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/leave-records`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '新增請假紀錄失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async deleteLeaveRecord(contractId: string, recordId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-contracts/${contractId}/leave-records/${recordId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '刪除請假紀錄失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    deleteLeaveRecord: (contractId: string, recordId: string) =>
+        apiDelete(`/api/v1/student-contracts/${contractId}/leave-records/${recordId}`, '刪除請假紀錄失敗'),
 }

--- a/frontend-dennis/src/lib/api/studentCourses.ts
+++ b/frontend-dennis/src/lib/api/studentCourses.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiDelete, qs } from './client'
 
 export interface StudentCourse {
     id: string
@@ -40,125 +38,21 @@ export interface CourseOption {
 }
 
 export const studentCoursesApi = {
-    async list(params?: {
-        page?: number
-        per_page?: number
-        student_id?: string
-        search?: string
-    }): Promise<{ data: StudentCourseListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.student_id) queryParams.set('student_id', params.student_id)
-            if (params?.search) queryParams.set('search', params.search)
+    list: (params?: { page?: number; per_page?: number; student_id?: string; search?: string }) =>
+        apiGet<StudentCourseListResponse>(`/api/v1/student-courses${qs(params || {})}`, '取得學生選課列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/student-courses${queryParams.toString() ? '?' + queryParams.toString() : ''}`
+    getByStudent: (studentId: string) =>
+        apiGet<StudentCourse[]>(`/api/v1/student-courses/by-student/${studentId}`, '取得學生選課失敗'),
 
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
+    create: (data: CreateStudentCourseData) =>
+        apiPost<StudentCourse>('/api/v1/student-courses', data, '新增學生選課失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '取得學生選課列表失敗' } }
-            }
+    delete: (enrollmentId: string) =>
+        apiDelete(`/api/v1/student-courses/${enrollmentId}`, '移除學生選課失敗'),
 
-            const result: StudentCourseListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getStudentOptions: () =>
+        apiGet<StudentOption[]>('/api/v1/student-courses/options/students', '取得學生選項失敗'),
 
-    async getByStudent(studentId: string): Promise<{ data: StudentCourse[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-courses/by-student/${studentId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得學生選課失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async create(data: CreateStudentCourseData): Promise<{ data: StudentCourse | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-courses`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '新增學生選課失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(enrollmentId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-courses/${enrollmentId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '移除學生選課失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getStudentOptions(): Promise<{ data: StudentOption[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-courses/options/students`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得學生選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getCourseOptions(): Promise<{ data: CourseOption[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-courses/options/courses`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得課程選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getCourseOptions: () =>
+        apiGet<CourseOption[]>('/api/v1/student-courses/options/courses', '取得課程選項失敗'),
 }

--- a/frontend-dennis/src/lib/api/studentTeacherPreferences.ts
+++ b/frontend-dennis/src/lib/api/studentTeacherPreferences.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiPut, apiDelete } from './client'
 
 export interface StudentTeacherPreference {
     id: string
@@ -34,142 +32,25 @@ export interface AllowedTeacher {
     teacher_level?: number
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const studentTeacherPreferencesApi = {
-    async list(studentId: string): Promise<{ data: StudentTeacherPreference[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-teacher-preferences?student_id=${studentId}`, {
-                method: 'GET',
-            })
+    list: (studentId: string) =>
+        apiGet<StudentTeacherPreference[]>(`/api/v1/student-teacher-preferences?student_id=${studentId}`, '取得偏好設定失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得偏好設定失敗' } }
-            }
+    create: (data: CreatePreferenceData) =>
+        apiPost<StudentTeacherPreference>('/api/v1/student-teacher-preferences', data, '建立偏好設定失敗'),
 
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    update: (preferenceId: string, data: UpdatePreferenceData) =>
+        apiPut<StudentTeacherPreference>(`/api/v1/student-teacher-preferences/${preferenceId}`, data, '更新偏好設定失敗'),
 
-    async create(data: CreatePreferenceData): Promise<{ data: StudentTeacherPreference | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-teacher-preferences`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
+    getAllowedTeachers: (studentId: string) =>
+        apiGet<AllowedTeacher[]>(`/api/v1/student-teacher-preferences/allowed-teachers?student_id=${studentId}`, '取得可預約教師失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '建立偏好設定失敗' } }
-            }
+    getTeacherOptions: () =>
+        apiGet<AllowedTeacher[]>('/api/v1/student-teacher-preferences/options/teachers', '取得教師選項失敗'),
 
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getCourseOptions: (studentId: string) =>
+        apiGet<{ id: string; course_name: string }[]>(`/api/v1/student-teacher-preferences/options/courses?student_id=${studentId}`, '取得課程選項失敗'),
 
-    async update(preferenceId: string, data: UpdatePreferenceData): Promise<{ data: StudentTeacherPreference | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-teacher-preferences/${preferenceId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新偏好設定失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getAllowedTeachers(studentId: string): Promise<{ data: AllowedTeacher[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-teacher-preferences/allowed-teachers?student_id=${studentId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得可預約教師失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getTeacherOptions(): Promise<{ data: AllowedTeacher[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-teacher-preferences/options/teachers`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getCourseOptions(studentId: string): Promise<{ data: { id: string, course_name: string }[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-teacher-preferences/options/courses?student_id=${studentId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得課程選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(preferenceId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/student-teacher-preferences/${preferenceId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '刪除偏好設定失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (preferenceId: string) =>
+        apiDelete(`/api/v1/student-teacher-preferences/${preferenceId}`, '刪除偏好設定失敗'),
 }

--- a/frontend-dennis/src/lib/api/students.ts
+++ b/frontend-dennis/src/lib/api/students.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiPut, apiDelete, qs } from './client'
 
 export interface Student {
     id: string
@@ -105,15 +103,6 @@ export interface UpdateStudentData {
     google_drive_folder_id?: string
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export interface ConvertToFormalData {
     contract_no: string
     total_lessons: number
@@ -146,151 +135,25 @@ export interface ConvertToFormalResponse {
 }
 
 export const studentsApi = {
-    async list(params?: {
-        page?: number
-        per_page?: number
-        search?: string
-        is_active?: boolean
-        student_type?: string
-    }): Promise<{ data: StudentListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.search) queryParams.set('search', params.search)
-            if (params?.is_active !== undefined) queryParams.set('is_active', params.is_active.toString())
-            if (params?.student_type) queryParams.set('student_type', params.student_type)
+    list: (params?: { page?: number; per_page?: number; search?: string; is_active?: boolean; student_type?: string }) =>
+        apiGet<StudentListResponse>(`/api/v1/students${qs(params || {})}`, '取得學生列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/students${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-            const response = await fetchWithAuth(url, { method: 'GET' })
+    create: (data: CreateStudentData) =>
+        apiPost<Student>('/api/v1/students', data, '建立學生失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得學生列表失敗' } }
-            }
+    update: (studentId: string, data: UpdateStudentData) =>
+        apiPut<Student>(`/api/v1/students/${studentId}`, data, '更新學生失敗'),
 
-            const result: StudentListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (studentId: string) =>
+        apiDelete(`/api/v1/students/${studentId}`, '刪除學生失敗'),
 
-    async create(data: CreateStudentData): Promise<{ data: Student | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/students`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
+    convertToFormal: (studentId: string, data: ConvertToFormalData) =>
+        apiPost<ConvertToFormalResponse>(`/api/v1/students/${studentId}/convert-to-formal`, data, '試上轉正失敗', { extractData: false }),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '建立學生失敗' } }
-            }
+    listOverview: (params?: { page?: number; per_page?: number; search?: string; student_type?: string; is_active?: boolean; has_account?: boolean; has_active_contract?: boolean; role?: string }) =>
+        apiGet<{ data: StudentOverviewItem[]; total: number; page: number; per_page: number; total_pages: number }>(
+            `/api/v1/students/overview/list${qs(params || {})}`, '取得學生總覽失敗', { extractData: false }),
 
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async update(studentId: string, data: UpdateStudentData): Promise<{ data: Student | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/students/${studentId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新學生失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(studentId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/students/${studentId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '刪除學生失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async convertToFormal(studentId: string, data: ConvertToFormalData): Promise<{ data: ConvertToFormalResponse | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/students/${studentId}/convert-to-formal`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '試上轉正失敗' } }
-            }
-
-            const result: ConvertToFormalResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async listOverview(params?: {
-        page?: number; per_page?: number; search?: string
-        student_type?: string; is_active?: boolean
-        has_account?: boolean; has_active_contract?: boolean
-        role?: string
-    }): Promise<{ data: { data: StudentOverviewItem[]; total: number; page: number; per_page: number; total_pages: number } | null, error: any }> {
-        try {
-            const sp = new URLSearchParams()
-            if (params?.page) sp.set('page', String(params.page))
-            if (params?.per_page) sp.set('per_page', String(params.per_page))
-            if (params?.search) sp.set('search', params.search)
-            if (params?.student_type) sp.set('student_type', params.student_type)
-            if (params?.is_active !== undefined) sp.set('is_active', String(params.is_active))
-            if (params?.has_account !== undefined) sp.set('has_account', String(params.has_account))
-            if (params?.has_active_contract !== undefined) sp.set('has_active_contract', String(params.has_active_contract))
-            if (params?.role) sp.set('role', params.role)
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/students/overview/list?${sp}`)
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得學生總覽失敗' } }
-            }
-            return { data: await response.json(), error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getView(studentId: string): Promise<{ data: StudentViewData | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/students/${studentId}/view`)
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得學生資訊失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getView: (studentId: string) =>
+        apiGet<StudentViewData>(`/api/v1/students/${studentId}/view`, '取得學生資訊失敗'),
 }

--- a/frontend-dennis/src/lib/api/substituteDetails.ts
+++ b/frontend-dennis/src/lib/api/substituteDetails.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiDelete, qs } from './client'
 
 export interface SubstituteDetail {
     id: string
@@ -28,69 +26,18 @@ export interface SubstituteDetailListResponse {
     total_pages: number
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const substituteDetailsApi = {
-    async create(data: {
+    create: (data: {
         booking_id: string
         substitute_teacher_id: string
         substitute_contract_id: string
         reason?: string
-    }): Promise<{ data: SubstituteDetail | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/substitute-details`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '指派代課失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    }) =>
+        apiPost<SubstituteDetail>('/api/v1/substitute-details', data, '指派代課失敗'),
 
-    async list(params?: { page?: number; per_page?: number }): Promise<{ data: SubstituteDetailListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            const url = `${API_BASE_URL}/api/v1/substitute-details${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-            const response = await fetchWithAuth(url, { method: 'GET' })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得代課紀錄失敗' } }
-            }
-            const result: SubstituteDetailListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    list: (params?: { page?: number; per_page?: number }) =>
+        apiGet<SubstituteDetailListResponse>(`/api/v1/substitute-details${qs(params || {})}`, '取得代課紀錄失敗', { extractData: false }),
 
-    async delete(subId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/substitute-details/${subId}`, {
-                method: 'DELETE',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '取消代課失敗' } }
-            }
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (subId: string) =>
+        apiDelete(`/api/v1/substitute-details/${subId}`, '取消代課失敗'),
 }

--- a/frontend-dennis/src/lib/api/teacherBonus.ts
+++ b/frontend-dennis/src/lib/api/teacherBonus.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiPut, apiDelete, qs } from './client'
 
 export type BonusType = 'trial_completed' | 'trial_to_formal' | 'performance' | 'substitute' | 'referral' | 'other'
 
@@ -66,120 +64,26 @@ export interface TeacherOption {
     name: string
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const teacherBonusApi = {
-    async list(params?: {
+    list: (params?: {
         page?: number
         per_page?: number
         teacher_id?: string
         bonus_type?: BonusType
         date_from?: string
         date_to?: string
-    }): Promise<{ data: TeacherBonusListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.teacher_id) queryParams.set('teacher_id', params.teacher_id)
-            if (params?.bonus_type) queryParams.set('bonus_type', params.bonus_type)
-            if (params?.date_from) queryParams.set('date_from', params.date_from)
-            if (params?.date_to) queryParams.set('date_to', params.date_to)
+    }) =>
+        apiGet<TeacherBonusListResponse>(`/api/v1/teacher-bonus${qs(params || {})}`, '取得教師獎金列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/teacher-bonus${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-            const response = await fetchWithAuth(url, { method: 'GET' })
+    create: (data: CreateTeacherBonusData) =>
+        apiPost<TeacherBonus>('/api/v1/teacher-bonus', data, '新增教師獎金失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師獎金列表失敗' } }
-            }
+    update: (bonusId: string, data: UpdateTeacherBonusData) =>
+        apiPut<TeacherBonus>(`/api/v1/teacher-bonus/${bonusId}`, data, '更新教師獎金失敗'),
 
-            const result: TeacherBonusListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (bonusId: string) =>
+        apiDelete(`/api/v1/teacher-bonus/${bonusId}`, '刪除教師獎金失敗'),
 
-    async create(data: CreateTeacherBonusData): Promise<{ data: TeacherBonus | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-bonus`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '新增教師獎金失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async update(bonusId: string, data: UpdateTeacherBonusData): Promise<{ data: TeacherBonus | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-bonus/${bonusId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新教師獎金失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(bonusId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-bonus/${bonusId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '刪除教師獎金失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getTeacherOptions(): Promise<{ data: TeacherOption[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-bonus/options/teachers`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: parseErrorDetail(error.detail) || '取得教師選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getTeacherOptions: () =>
+        apiGet<TeacherOption[]>('/api/v1/teacher-bonus/options/teachers', '取得教師選項失敗'),
 }

--- a/frontend-dennis/src/lib/api/teacherContracts.ts
+++ b/frontend-dennis/src/lib/api/teacherContracts.ts
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiGet, apiPost, apiPut, apiDelete, qs } from './client'
 
 export type ContractStatus = 'pending' | 'active' | 'expired' | 'terminated' | 'suspended'
 export type EmploymentType = 'hourly' | 'full_time'
@@ -130,120 +130,29 @@ export interface TeacherOption {
 }
 
 export const teacherContractsApi = {
-    async list(params?: {
+    list: (params?: {
         page?: number
         per_page?: number
         search?: string
         contract_status?: ContractStatus
         employment_type?: EmploymentType
         teacher_id?: string
-    }): Promise<{ data: TeacherContractListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.search) queryParams.set('search', params.search)
-            if (params?.contract_status) queryParams.set('contract_status', params.contract_status)
-            if (params?.employment_type) queryParams.set('employment_type', params.employment_type)
-            if (params?.teacher_id) queryParams.set('teacher_id', params.teacher_id)
+    }) =>
+        apiGet<TeacherContractListResponse>(`/api/v1/teacher-contracts${qs(params || {})}`, '取得教師合約列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/teacher-contracts${queryParams.toString() ? '?' + queryParams.toString() : ''}`
+    get: (contractId: string) =>
+        apiGet<TeacherContract>(`/api/v1/teacher-contracts/${contractId}`, '取得教師合約失敗'),
 
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
+    create: (data: CreateTeacherContractData) =>
+        apiPost<TeacherContract>('/api/v1/teacher-contracts', data, '建立教師合約失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '取得教師合約列表失敗' } }
-            }
+    update: (contractId: string, data: UpdateTeacherContractData) =>
+        apiPut<TeacherContract>(`/api/v1/teacher-contracts/${contractId}`, data, '更新教師合約失敗'),
 
-            const result: TeacherContractListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (contractId: string) =>
+        apiDelete(`/api/v1/teacher-contracts/${contractId}`, '刪除教師合約失敗'),
 
-    async get(contractId: string): Promise<{ data: TeacherContract | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '取得教師合約失敗' } }
-            }
-
-            const result: TeacherContractResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async create(data: CreateTeacherContractData): Promise<{ data: TeacherContract | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '建立教師合約失敗' } }
-            }
-
-            const result: TeacherContractResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async update(contractId: string, data: UpdateTeacherContractData): Promise<{ data: TeacherContract | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '更新教師合約失敗' } }
-            }
-
-            const result: TeacherContractResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(contractId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '刪除教師合約失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
+    // Presigned URL upload flow — keep fetchWithAuth
     async uploadFile(contractId: string, file: File): Promise<{ data: TeacherContract | null, error: any }> {
         try {
             const fileExt = file.name.split('.').pop()?.toLowerCase() || 'pdf'
@@ -289,12 +198,10 @@ export const teacherContractsApi = {
 
     async generatePdf(contractId: string): Promise<{ success: boolean, error: any }> {
         try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/generate-pdf`, {
-                method: 'GET',
-            })
+            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/generate-pdf`)
             if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '產生合約 PDF 失敗' } }
+                const err = await response.json()
+                return { success: false, error: { message: err.detail || '產生合約 PDF 失敗' } }
             }
             const blob = await response.blob()
             const contentDisposition = response.headers.get('Content-Disposition')
@@ -312,184 +219,45 @@ export const teacherContractsApi = {
             document.body.removeChild(a)
             window.URL.revokeObjectURL(url)
             return { success: true, error: null }
-        } catch (err) {
+        } catch {
             return { success: false, error: { message: '網路錯誤，請稍後再試' } }
         }
     },
 
     async downloadFile(contractId: string): Promise<{ url: string | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/download-url`, {
-                method: 'GET',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { url: null, error: { message: error.detail || '取得下載連結失敗' } }
-            }
-            const { download_url } = await response.json()
-            return { url: download_url, error: null }
-        } catch (err) {
-            return { url: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
+        const { data, error } = await apiGet<{ download_url: string }>(`/api/v1/teacher-contracts/${contractId}/download-url`, '取得下載連結失敗', { extractData: false })
+        if (error) return { url: null, error }
+        return { url: data!.download_url, error: null }
     },
 
-    async getTeacherOptions(): Promise<{ data: TeacherOption[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/options/teachers`, {
-                method: 'GET',
-            })
+    getTeacherOptions: () =>
+        apiGet<TeacherOption[]>('/api/v1/teacher-contracts/options/teachers', '取得教師選項失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得教師選項失敗' } }
-            }
+    getCourseOptions: () =>
+        apiGet<CourseOption[]>('/api/v1/teacher-contracts/options/courses', '取得課程選項失敗'),
 
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    // ========== Details API ==========
 
-    async getCourseOptions(): Promise<{ data: CourseOption[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/options/courses`, {
-                method: 'GET',
-            })
+    listDetails: (contractId: string) =>
+        apiGet<TeacherContractDetail[]>(`/api/v1/teacher-contracts/${contractId}/details`, '取得合約明細失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得課程選項失敗' } }
-            }
+    createDetail: (contractId: string, data: CreateDetailData) =>
+        apiPost<TeacherContractDetail>(`/api/v1/teacher-contracts/${contractId}/details`, data, '新增合約明細失敗'),
 
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    updateDetail: (contractId: string, detailId: string, data: UpdateDetailData) =>
+        apiPut<TeacherContractDetail>(`/api/v1/teacher-contracts/${contractId}/details/${detailId}`, data, '更新合約明細失敗'),
 
-    async listDetails(contractId: string): Promise<{ data: TeacherContractDetail[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/details`, {
-                method: 'GET',
-            })
+    deleteDetail: (contractId: string, detailId: string) =>
+        apiDelete(`/api/v1/teacher-contracts/${contractId}/details/${detailId}`, '刪除合約明細失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得合約明細失敗' } }
-            }
+    // ========== Work Schedules API ==========
 
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    listWorkSchedules: (contractId: string) =>
+        apiGet<TeacherWorkSchedule[]>(`/api/v1/teacher-contracts/${contractId}/work-schedules`, '取得工作時段失敗'),
 
-    async createDetail(contractId: string, data: CreateDetailData): Promise<{ data: TeacherContractDetail | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/details`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
+    setWorkSchedules: (contractId: string, schedules: TeacherWorkScheduleInput[]) =>
+        apiPut<TeacherWorkSchedule[]>(`/api/v1/teacher-contracts/${contractId}/work-schedules`, { schedules }, '更新工作時段失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '新增合約明細失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async updateDetail(contractId: string, detailId: string, data: UpdateDetailData): Promise<{ data: TeacherContractDetail | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/details/${detailId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: error.detail || '更新合約明細失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async deleteDetail(contractId: string, detailId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/details/${detailId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '刪除合約明細失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async listWorkSchedules(contractId: string): Promise<{ data: TeacherWorkSchedule[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/work-schedules`, {
-                method: 'GET',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '取得工作時段失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async setWorkSchedules(contractId: string, schedules: TeacherWorkScheduleInput[]): Promise<{ data: TeacherWorkSchedule[], error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/work-schedules`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ schedules }),
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: [], error: { message: error.detail || '更新工作時段失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: [], error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async clearWorkSchedules(contractId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-contracts/${contractId}/work-schedules`, {
-                method: 'DELETE',
-            })
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: error.detail || '清除工作時段失敗' } }
-            }
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    clearWorkSchedules: (contractId: string) =>
+        apiDelete(`/api/v1/teacher-contracts/${contractId}/work-schedules`, '清除工作時段失敗'),
 }

--- a/frontend-dennis/src/lib/api/teacherDetails.ts
+++ b/frontend-dennis/src/lib/api/teacherDetails.ts
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiGet, apiPost, apiPut, apiDelete } from './client'
 
 export type TeacherDetailType = 'qualification' | 'certificate' | 'video' | 'experience'
 
@@ -36,15 +36,6 @@ export interface UpdateTeacherDetailData {
     expiry_date?: string
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const DETAIL_TYPE_LABELS: Record<TeacherDetailType, string> = {
     qualification: '學歷',
     certificate: '證照',
@@ -53,79 +44,17 @@ export const DETAIL_TYPE_LABELS: Record<TeacherDetailType, string> = {
 }
 
 export const teacherDetailsApi = {
-    async list(teacherId: string): Promise<{ data: TeacherDetailListResponse | null, error: any }> {
-        try {
-            const url = `${API_BASE_URL}/api/v1/teacher-details?teacher_id=${teacherId}`
-            const response = await fetchWithAuth(url, { method: 'GET' })
+    list: (teacherId: string) =>
+        apiGet<TeacherDetailListResponse>(`/api/v1/teacher-details?teacher_id=${teacherId}`, '取得教師明細失敗', { extractData: false }),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師明細失敗' } }
-            }
+    create: (data: CreateTeacherDetailData) =>
+        apiPost<TeacherDetail>('/api/v1/teacher-details', data, '新增教師明細失敗'),
 
-            const result: TeacherDetailListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    update: (detailId: string, data: UpdateTeacherDetailData) =>
+        apiPut<TeacherDetail>(`/api/v1/teacher-details/${detailId}`, data, '更新教師明細失敗'),
 
-    async create(data: CreateTeacherDetailData): Promise<{ data: TeacherDetail | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-details`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '新增教師明細失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async update(detailId: string, data: UpdateTeacherDetailData): Promise<{ data: TeacherDetail | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-details/${detailId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新教師明細失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(detailId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-details/${detailId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '刪除教師明細失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (detailId: string) =>
+        apiDelete(`/api/v1/teacher-details/${detailId}`, '刪除教師明細失敗'),
 
     async getUploadUrl(detailId: string, fileName: string): Promise<{ data: { upload_url: string, storage_path: string } | null, error: any }> {
         try {
@@ -137,7 +66,7 @@ export const teacherDetailsApi = {
 
             if (!response.ok) {
                 const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得上傳連結失敗' } }
+                return { data: null, error: { message: error.detail || '取得上傳連結失敗' } }
             }
 
             const result = await response.json()
@@ -157,7 +86,7 @@ export const teacherDetailsApi = {
 
             if (!response.ok) {
                 const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '確認上傳失敗' } }
+                return { data: null, error: { message: error.detail || '確認上傳失敗' } }
             }
 
             const result = await response.json()
@@ -175,7 +104,7 @@ export const teacherDetailsApi = {
 
             if (!response.ok) {
                 const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得下載連結失敗' } }
+                return { data: null, error: { message: error.detail || '取得下載連結失敗' } }
             }
 
             const result = await response.json()

--- a/frontend-dennis/src/lib/api/teacherSlots.ts
+++ b/frontend-dennis/src/lib/api/teacherSlots.ts
@@ -1,6 +1,4 @@
-import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { apiGet, apiPost, apiPut, apiAction, apiDelete, qs } from './client'
 
 export interface TeacherSlot {
     id: string
@@ -114,18 +112,8 @@ export interface TeacherContractOption {
     contract_no: string
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        // Pydantic validation errors: "Value error, 實際訊息"
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const teacherSlotsApi = {
-    async list(params?: {
+    list: (params?: {
         page?: number
         per_page?: number
         teacher_id?: string
@@ -133,259 +121,41 @@ export const teacherSlotsApi = {
         date_to?: string
         is_available?: boolean
         is_booked?: boolean
-    }): Promise<{ data: TeacherSlotListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.teacher_id) queryParams.set('teacher_id', params.teacher_id)
-            if (params?.date_from) queryParams.set('date_from', params.date_from)
-            if (params?.date_to) queryParams.set('date_to', params.date_to)
-            if (params?.is_available !== undefined) queryParams.set('is_available', params.is_available.toString())
-            if (params?.is_booked !== undefined) queryParams.set('is_booked', params.is_booked.toString())
+    }) =>
+        apiGet<TeacherSlotListResponse>(`/api/v1/teacher-slots${qs(params || {})}`, '取得教師時段列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/teacher-slots${queryParams.toString() ? '?' + queryParams.toString() : ''}`
+    get: (slotId: string) =>
+        apiGet<TeacherSlot>(`/api/v1/teacher-slots/${slotId}`, '取得教師時段失敗'),
 
-            const response = await fetchWithAuth(url, {
-                method: 'GET',
-            })
+    create: (data: CreateTeacherSlotData) =>
+        apiPost<TeacherSlot>('/api/v1/teacher-slots', data, '建立教師時段失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師時段列表失敗' } }
-            }
+    createBatch: (data: BatchCreateTeacherSlotData) =>
+        apiAction('POST', '/api/v1/teacher-slots/batch', data, '批次建立教師時段失敗'),
 
-            const result: TeacherSlotListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    deleteBatch: (data: BatchDeleteTeacherSlotData) =>
+        apiAction('DELETE', '/api/v1/teacher-slots/batch', data, '批次刪除教師時段失敗'),
 
-    async get(slotId: string): Promise<{ data: TeacherSlot | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/${slotId}`, {
-                method: 'GET',
-            })
+    updateBatch: (data: BatchUpdateTeacherSlotData) =>
+        apiAction('PUT', '/api/v1/teacher-slots/batch', data, '批次更新教師時段失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師時段失敗' } }
-            }
+    deleteByIds: (data: BatchDeleteByIdsData) =>
+        apiAction('POST', '/api/v1/teacher-slots/batch-by-ids/delete', data, '批次刪除教師時段失敗'),
 
-            const result: TeacherSlotResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    updateByIds: (data: BatchUpdateByIdsData) =>
+        apiAction('POST', '/api/v1/teacher-slots/batch-by-ids/update', data, '批次更新教師時段失敗'),
 
-    async create(data: CreateTeacherSlotData): Promise<{ data: TeacherSlot | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
+    update: (slotId: string, data: UpdateTeacherSlotData) =>
+        apiPut<TeacherSlot>(`/api/v1/teacher-slots/${slotId}`, data, '更新教師時段失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '建立教師時段失敗' } }
-            }
-
-            const result: TeacherSlotResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async createBatch(data: BatchCreateTeacherSlotData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/batch`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次建立教師時段失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async deleteBatch(data: BatchDeleteTeacherSlotData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/batch`, {
-                method: 'DELETE',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次刪除教師時段失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async updateBatch(data: BatchUpdateTeacherSlotData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/batch`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次更新教師時段失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async deleteByIds(data: BatchDeleteByIdsData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/batch-by-ids/delete`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次刪除教師時段失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async updateByIds(data: BatchUpdateByIdsData): Promise<{ success: boolean, message?: string, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/batch-by-ids/update`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '批次更新教師時段失敗' } }
-            }
-
-            const result = await response.json()
-            return { success: true, message: result.message, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async update(slotId: string, data: UpdateTeacherSlotData): Promise<{ data: TeacherSlot | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/${slotId}`, {
-                method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新教師時段失敗' } }
-            }
-
-            const result: TeacherSlotResponse = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(slotId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/${slotId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '刪除教師時段失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    delete: (slotId: string) =>
+        apiDelete(`/api/v1/teacher-slots/${slotId}`, '刪除教師時段失敗'),
 
     // 取得下拉選單選項（僅限員工）
-    async getTeacherOptions(): Promise<{ data: TeacherOption[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/options/teachers`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getTeacherOptions: () =>
+        apiGet<TeacherOption[]>('/api/v1/teacher-slots/options/teachers', '取得教師選項失敗'),
 
     // 取得當前教師的合約
-    async getMyContracts(): Promise<{ data: TeacherContractOption[] | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teacher-slots/my-contracts`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師合約選項失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || [], error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getMyContracts: () =>
+        apiGet<TeacherContractOption[]>('/api/v1/teacher-slots/my-contracts', '取得教師合約選項失敗'),
 }

--- a/frontend-dennis/src/lib/api/teachers.ts
+++ b/frontend-dennis/src/lib/api/teachers.ts
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiGet, apiPost, apiPut, apiDelete, qs } from './client'
 
 export interface Teacher {
     id: string
@@ -103,198 +103,63 @@ export interface TeacherSelfUpdateData {
     address?: string
 }
 
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
 export const teachersApi = {
-    async list(params?: {
-        page?: number
-        per_page?: number
-        search?: string
-        is_active?: boolean
-    }): Promise<{ data: TeacherListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.search) queryParams.set('search', params.search)
-            if (params?.is_active !== undefined) queryParams.set('is_active', params.is_active.toString())
+    list: (params?: { page?: number; per_page?: number; search?: string; is_active?: boolean }) =>
+        apiGet<TeacherListResponse>(`/api/v1/teachers${qs(params || {})}`, '取得教師列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/teachers${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-            const response = await fetchWithAuth(url, { method: 'GET' })
+    create: (data: CreateTeacherData) =>
+        apiPost<Teacher>('/api/v1/teachers', data, '建立教師失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師列表失敗' } }
-            }
+    update: (teacherId: string, data: UpdateTeacherData) =>
+        apiPut<Teacher>(`/api/v1/teachers/${teacherId}`, data, '更新教師失敗'),
 
-            const result: TeacherListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    updateSelf: (data: TeacherSelfUpdateData) =>
+        apiPut<Teacher>('/api/v1/teachers/me', data, '更新個人資料失敗'),
 
-    async create(data: CreateTeacherData): Promise<{ data: Teacher | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teachers`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
+    delete: (teacherId: string) =>
+        apiDelete(`/api/v1/teachers/${teacherId}`, '刪除教師失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '建立教師失敗' } }
-            }
+    listOverview: (params?: { page?: number; per_page?: number; search?: string; is_active?: boolean; has_account?: boolean; has_active_contract?: boolean; role?: string }) =>
+        apiGet<{ data: TeacherOverviewItem[]; total: number; page: number; per_page: number; total_pages: number }>(
+            `/api/v1/teachers/overview/list${qs(params || {})}`, '取得教師總覽失敗', { extractData: false }),
 
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    getView: (teacherId: string) =>
+        apiGet<TeacherViewData>(`/api/v1/teachers/${teacherId}/view`, '取得教師資訊失敗'),
 
-    async update(teacherId: string, data: UpdateTeacherData): Promise<{ data: Teacher | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teachers/${teacherId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新教師失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async updateSelf(data: TeacherSelfUpdateData): Promise<{ data: Teacher | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teachers/me`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新個人資料失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async delete(teacherId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teachers/${teacherId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '刪除教師失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
+    /** 頭像上傳（presigned URL 流程，無法用 apiPost 簡化） */
     async uploadAvatar(teacherId: string, file: File): Promise<{ data: Teacher | null, error: any }> {
         try {
-            // 1. 取得 presigned URL
             const urlRes = await fetchWithAuth(`${API_BASE_URL}/api/v1/teachers/${teacherId}/avatar/upload-url`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ file_name: file.name }),
             })
             if (!urlRes.ok) {
-                const error = await urlRes.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得上傳連結失敗' } }
+                const err = await urlRes.json()
+                return { data: null, error: { message: err.detail || '取得上傳連結失敗' } }
             }
             const { upload_url, storage_path, content_type } = await urlRes.json()
 
-            // 2. PUT 到 S3（Content-Type 必須與 presigned URL 簽名一致）
             const uploadRes = await fetch(upload_url, {
                 method: 'PUT',
                 headers: { 'Content-Type': content_type || file.type || 'application/octet-stream' },
                 body: file,
             })
-            if (!uploadRes.ok) {
-                return { data: null, error: { message: '頭像上傳失敗' } }
-            }
+            if (!uploadRes.ok) return { data: null, error: { message: '頭像上傳失敗' } }
 
-            // 3. 確認上傳
             const confirmRes = await fetchWithAuth(`${API_BASE_URL}/api/v1/teachers/${teacherId}/avatar/confirm-upload`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ storage_path, file_name: file.name }),
             })
             if (!confirmRes.ok) {
-                const error = await confirmRes.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '確認上傳失敗' } }
+                const err = await confirmRes.json()
+                return { data: null, error: { message: err.detail || '確認上傳失敗' } }
             }
             const result = await confirmRes.json()
             return { data: result.data || null, error: null }
-        } catch (err) {
+        } catch {
             return { data: null, error: { message: '網路錯誤' } }
-        }
-    },
-
-    async listOverview(params?: {
-        page?: number; per_page?: number; search?: string
-        is_active?: boolean; has_account?: boolean
-        has_active_contract?: boolean; role?: string
-    }): Promise<{ data: { data: TeacherOverviewItem[]; total: number; page: number; per_page: number; total_pages: number } | null, error: any }> {
-        try {
-            const sp = new URLSearchParams()
-            if (params?.page) sp.set('page', String(params.page))
-            if (params?.per_page) sp.set('per_page', String(params.per_page))
-            if (params?.search) sp.set('search', params.search)
-            if (params?.is_active !== undefined) sp.set('is_active', String(params.is_active))
-            if (params?.has_account !== undefined) sp.set('has_account', String(params.has_account))
-            if (params?.has_active_contract !== undefined) sp.set('has_active_contract', String(params.has_active_contract))
-            if (params?.role) sp.set('role', params.role)
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teachers/overview/list?${sp}`)
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師總覽失敗' } }
-            }
-            return { data: await response.json(), error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getView(teacherId: string): Promise<{ data: TeacherViewData | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/teachers/${teacherId}/view`)
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得教師資訊失敗' } }
-            }
-            const result = await response.json()
-            return { data: result.data, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
         }
     },
 }

--- a/frontend-dennis/src/lib/api/types.ts
+++ b/frontend-dennis/src/lib/api/types.ts
@@ -1,0 +1,29 @@
+/** 後端統一錯誤回傳格式 */
+export interface ApiErrorBody {
+  success: false
+  message: string
+  detail: string
+  error_code: string
+}
+
+/** 前端 API 函式統一錯誤物件 */
+export interface ApiError {
+  message: string   // 給使用者看的中文訊息
+  code: string      // 後端 error_code (e.g. "NOT_FOUND", "FORBIDDEN_PAGE")
+  status: number    // HTTP status code
+}
+
+/** 回傳資料的 API 結果 */
+export type ApiResult<T> =
+  | { data: T; error: null }
+  | { data: null; error: ApiError }
+
+/** 不回傳資料的 API 結果（DELETE 等） */
+export type ApiActionResult =
+  | { success: true; message: string; error: null }
+  | { success: false; message: string; error: ApiError }
+
+/** Blob 下載結果 */
+export type ApiBlobResult =
+  | { blob: Blob; error: null }
+  | { blob: null; error: ApiError }

--- a/frontend-dennis/src/lib/api/zoom.ts
+++ b/frontend-dennis/src/lib/api/zoom.ts
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from './fetchWithAuth'
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8001'
+import { API_BASE_URL } from './config'
+import { apiGet, apiPost, apiPut, apiDelete, apiAction, qs } from './client'
 
 // ============================================
 // Types
@@ -99,157 +99,33 @@ export interface ZoomTeacherLinkStatus {
 }
 
 // ============================================
-// Helper
-// ============================================
-
-function parseErrorDetail(detail: unknown): string {
-    if (typeof detail === 'string') return detail
-    if (Array.isArray(detail) && detail.length > 0) {
-        const msg = detail[0]?.msg || ''
-        return msg.replace(/^Value error,\s*/, '')
-    }
-    return ''
-}
-
-// ============================================
 // API
 // ============================================
 
 export const zoomApi = {
     // --- 帳號池 CRUD ---
 
-    async listAccounts(params?: {
-        page?: number
-        per_page?: number
-        is_active?: boolean
-    }): Promise<{ data: ZoomAccountListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.is_active !== undefined) queryParams.set('is_active', params.is_active.toString())
+    listAccounts: (params?: { page?: number; per_page?: number; is_active?: boolean }) =>
+        apiGet<ZoomAccountListResponse>(`/api/v1/zoom/accounts${qs(params || {})}`, '取得 Zoom 帳號列表失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/zoom/accounts${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-            const response = await fetchWithAuth(url, { method: 'GET' })
+    createAccount: (data: CreateZoomAccountData) =>
+        apiPost<ZoomAccount>('/api/v1/zoom/accounts', data, '新增 Zoom 帳號失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得 Zoom 帳號列表失敗' } }
-            }
+    updateAccount: (accountId: string, data: UpdateZoomAccountData) =>
+        apiPut<ZoomAccount>(`/api/v1/zoom/accounts/${accountId}`, data, '更新 Zoom 帳號失敗'),
 
-            const result: ZoomAccountListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    deleteAccount: (accountId: string) =>
+        apiDelete(`/api/v1/zoom/accounts/${accountId}`, '刪除 Zoom 帳號失敗'),
 
-    async createAccount(data: CreateZoomAccountData): Promise<{ data: ZoomAccount | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/accounts`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '新增 Zoom 帳號失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async updateAccount(accountId: string, data: UpdateZoomAccountData): Promise<{ data: ZoomAccount | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/accounts/${accountId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data),
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '更新 Zoom 帳號失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async deleteAccount(accountId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/accounts/${accountId}`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '刪除 Zoom 帳號失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async testAccount(accountId: string): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/accounts/${accountId}/test`, {
-                method: 'POST',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '測試連線失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    testAccount: (accountId: string) =>
+        apiAction('POST', `/api/v1/zoom/accounts/${accountId}/test`, undefined, '測試連線失敗'),
 
     // --- 會議操作 ---
 
-    async listMeetings(params?: {
-        page?: number
-        per_page?: number
-        meeting_status?: string
-        date_from?: string
-        date_to?: string
-    }): Promise<{ data: ZoomMeetingLogListResponse | null, error: any }> {
-        try {
-            const queryParams = new URLSearchParams()
-            if (params?.page) queryParams.set('page', params.page.toString())
-            if (params?.per_page) queryParams.set('per_page', params.per_page.toString())
-            if (params?.meeting_status) queryParams.set('meeting_status', params.meeting_status)
-            if (params?.date_from) queryParams.set('date_from', params.date_from)
-            if (params?.date_to) queryParams.set('date_to', params.date_to)
+    listMeetings: (params?: { page?: number; per_page?: number; meeting_status?: string; date_from?: string; date_to?: string }) =>
+        apiGet<ZoomMeetingLogListResponse>(`/api/v1/zoom/meetings${qs(params || {})}`, '取得會議紀錄失敗', { extractData: false }),
 
-            const url = `${API_BASE_URL}/api/v1/zoom/meetings${queryParams.toString() ? '?' + queryParams.toString() : ''}`
-            const response = await fetchWithAuth(url, { method: 'GET' })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得會議紀錄失敗' } }
-            }
-
-            const result: ZoomMeetingLogListResponse = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
+    /** 特殊：404 視為 data=null 而非錯誤 */
     async getMeetingByBooking(bookingId: string): Promise<{ data: ZoomMeetingLog | null, error: any }> {
         try {
             const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/meetings/${bookingId}`, {
@@ -261,7 +137,7 @@ export const zoomApi = {
                     return { data: null, error: null }
                 }
                 const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得會議資訊失敗' } }
+                return { data: null, error: { message: error.detail || '取得會議資訊失敗' } }
             }
 
             const result = await response.json()
@@ -271,99 +147,20 @@ export const zoomApi = {
         }
     },
 
-    async createMeeting(bookingId: string): Promise<{ data: ZoomMeetingLog | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/meetings/create`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ booking_id: bookingId }),
-            })
+    createMeeting: (bookingId: string) =>
+        apiPost<ZoomMeetingLog>('/api/v1/zoom/meetings/create', { booking_id: bookingId }, '建立 Zoom 會議失敗'),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '建立 Zoom 會議失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async fetchRecording(bookingId: string): Promise<{ data: ZoomMeetingLog | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/meetings/${bookingId}/fetch-recording`, {
-                method: 'POST',
-            })
-
-            if (!response.ok) {
-                if (response.status === 404) {
-                    return { data: null, error: { message: '尚無可用的錄影，請確認會議已結束' } }
-                }
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得錄影失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result.data || null, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    fetchRecording: (bookingId: string) =>
+        apiPost<ZoomMeetingLog>(`/api/v1/zoom/meetings/${bookingId}/fetch-recording`, undefined, '取得錄影失敗'),
 
     // --- 教師 OAuth ---
 
-    async getOAuthStatus(): Promise<{ data: ZoomTeacherLinkStatus | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/oauth/status`, {
-                method: 'GET',
-            })
+    getOAuthStatus: () =>
+        apiGet<ZoomTeacherLinkStatus>('/api/v1/zoom/oauth/status', '取得 Zoom 綁定狀態失敗', { extractData: false }),
 
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得 Zoom 綁定狀態失敗' } }
-            }
+    getOAuthUrl: () =>
+        apiGet<{ authorize_url: string }>('/api/v1/zoom/oauth/authorize', '取得授權連結失敗', { extractData: false }),
 
-            const result: ZoomTeacherLinkStatus = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async getOAuthUrl(): Promise<{ data: { authorize_url: string } | null, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/oauth/authorize`, {
-                method: 'GET',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { data: null, error: { message: parseErrorDetail(error.detail) || '取得授權連結失敗' } }
-            }
-
-            const result = await response.json()
-            return { data: result, error: null }
-        } catch (err) {
-            return { data: null, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
-
-    async unlinkZoom(): Promise<{ success: boolean, error: any }> {
-        try {
-            const response = await fetchWithAuth(`${API_BASE_URL}/api/v1/zoom/oauth/unlink`, {
-                method: 'DELETE',
-            })
-
-            if (!response.ok) {
-                const error = await response.json()
-                return { success: false, error: { message: parseErrorDetail(error.detail) || '解除 Zoom 綁定失敗' } }
-            }
-
-            return { success: true, error: null }
-        } catch (err) {
-            return { success: false, error: { message: '網路錯誤，請稍後再試' } }
-        }
-    },
+    unlinkZoom: () =>
+        apiDelete('/api/v1/zoom/oauth/unlink', '解除 Zoom 綁定失敗'),
 }

--- a/supabase/migrations/051_auto_number_sequences.sql
+++ b/supabase/migrations/051_auto_number_sequences.sql
@@ -1,0 +1,36 @@
+-- 自動編號 Sequence（取代字串排序 + 手動 +1）
+-- EOPS = 學生編號, EOPT = 教師編號
+-- 從現有資料庫最大值 +1 開始，確保不衝突
+
+DO $$
+DECLARE
+    max_student INT;
+    max_teacher INT;
+BEGIN
+    -- 取得目前最大的 EOPS 編號
+    SELECT COALESCE(MAX(CAST(SUBSTRING(student_no FROM 5) AS INTEGER)), -1) + 1
+    INTO max_student
+    FROM students
+    WHERE student_no ~ '^EOPS[0-9]+$';
+
+    -- 取得目前最大的 EOPT 編號
+    SELECT COALESCE(MAX(CAST(SUBSTRING(teacher_no FROM 5) AS INTEGER)), -1) + 1
+    INTO max_teacher
+    FROM teachers
+    WHERE teacher_no ~ '^EOPT[0-9]+$';
+
+    -- 建立 sequence（如果已存在則跳過）
+    IF NOT EXISTS (SELECT 1 FROM pg_sequences WHERE sequencename = 'students_eops_seq') THEN
+        EXECUTE format('CREATE SEQUENCE students_eops_seq START %s MINVALUE 0', max_student);
+    ELSE
+        EXECUTE format('ALTER SEQUENCE students_eops_seq RESTART WITH %s', max_student);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_sequences WHERE sequencename = 'teachers_eopt_seq') THEN
+        EXECUTE format('CREATE SEQUENCE teachers_eopt_seq START %s MINVALUE 0', max_teacher);
+    ELSE
+        EXECUTE format('ALTER SEQUENCE teachers_eopt_seq RESTART WITH %s', max_teacher);
+    END IF;
+
+    RAISE NOTICE 'students_eops_seq starts at %, teachers_eopt_seq starts at %', max_student, max_teacher;
+END $$;


### PR DESCRIPTION
- 新增 ErrorCode StrEnum（22 個錯誤碼）與 infer_error_code 自動推斷
- 重構 exceptions.py：AppException 基底類別 + 工廠函式（not_found, duplicate, forbidden, bad_request, conflict）
- 統一全域 exception handler 回傳格式（message + detail + error_code）
- 修正 middleware 回傳格式與全域 handler 一致