### PR TITLE
refactor: 補齊所有端點 response_model + 新增錯誤碼文件

### DIFF
--- a/backend/app/api/v1/alerts.py
+++ b/backend/app/api/v1/alerts.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Query, HTTPException
 from app.services.supabase_service import supabase_service
 from app.core.dependencies import CurrentUser, require_staff, require_page_permission
-from app.schemas.response import BaseResponse
+from app.schemas.response import BaseResponse, AlertListResponse, UnreadCountResponse
 from typing import Optional
 import math
 import uuid
@@ -11,7 +11,7 @@ router = APIRouter(prefix="/alerts", tags=["系統告警"])
 ALERT_SELECT = "id,alert_type,severity,title,message,metadata,is_read,read_by,read_at,created_at"
 
 
-@router.get("")
+@router.get("", response_model=AlertListResponse)
 async def list_alerts(
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
@@ -129,7 +129,7 @@ async def mark_all_read(
         raise HTTPException(status_code=500, detail=f"標記失敗: {e}")
 
 
-@router.get("/unread-count")
+@router.get("/unread-count", response_model=UnreadCountResponse)
 async def get_unread_count(
     current_user: CurrentUser = Depends(require_page_permission("dashboard.alerts")),
 ):

--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -7,8 +7,8 @@ from app.schemas.booking import (
     BookingBatchUpdateByIds, BookingBatchDeleteByIds, BookingBatchUpdate, BookingBatchDelete,
     BookingBatchCreate, TimeBlock, SlotAvailabilityResponse
 )
-from app.schemas.response import BaseResponse, DataResponse
-from typing import Optional
+from app.schemas.response import BaseResponse, DataResponse, StudentOption, TeacherOption, CourseOption, ContractOption, SlotOption
+from typing import Optional, List
 from datetime import date, datetime, time
 import asyncio
 import logging
@@ -924,7 +924,7 @@ async def get_slot_availability(
         raise HTTPException(status_code=500, detail=f"取得時段可用狀態失敗: {str(e)}")
 
 
-@router.get("/my-student-info", tags=["預約管理"], response_model=DataResponse)
+@router.get("/my-student-info", tags=["預約管理"], response_model=DataResponse[Optional[StudentOption]])
 async def get_my_student_info(
     current_user: CurrentUser = Depends(get_current_user)
 ):
@@ -949,7 +949,7 @@ async def get_my_student_info(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/my-contracts", tags=["預約管理"], response_model=DataResponse)
+@router.get("/my-contracts", tags=["預約管理"], response_model=DataResponse[List[ContractOption]])
 async def get_my_contracts(
     current_user: CurrentUser = Depends(get_current_user)
 ):
@@ -2490,7 +2490,7 @@ async def batch_delete_bookings_by_ids(
 # 輔助 API：取得下拉選單資料
 # ============================================
 
-@router.get("/options/students", tags=["預約管理"], response_model=DataResponse)
+@router.get("/options/students", tags=["預約管理"], response_model=DataResponse[List[StudentOption]])
 async def get_student_options(
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
 ):
@@ -2506,7 +2506,7 @@ async def get_student_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teachers", tags=["預約管理"], response_model=DataResponse)
+@router.get("/options/teachers", tags=["預約管理"], response_model=DataResponse[List[TeacherOption]])
 async def get_teacher_options(
     student_id: Optional[str] = Query(None, description="學生 ID（用於偏好過濾）"),
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
@@ -2537,7 +2537,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/overlapping-courses", tags=["預約管理"], response_model=DataResponse)
+@router.get("/options/overlapping-courses", tags=["預約管理"], response_model=DataResponse[List[CourseOption]])
 async def get_overlapping_course_options(
     student_id: str = Query(..., description="學生 ID"),
     teacher_id: str = Query(..., description="教師 ID"),
@@ -2627,7 +2627,7 @@ async def get_overlapping_course_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/courses", tags=["預約管理"], response_model=DataResponse)
+@router.get("/options/courses", tags=["預約管理"], response_model=DataResponse[List[CourseOption]])
 async def get_course_options(
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
 ):
@@ -2643,7 +2643,7 @@ async def get_course_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/student-contracts/{student_id}", tags=["預約管理"], response_model=DataResponse)
+@router.get("/options/student-contracts/{student_id}", tags=["預約管理"], response_model=DataResponse[List[ContractOption]])
 async def get_student_contract_options(
     student_id: str,
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
@@ -2696,7 +2696,7 @@ async def get_student_contract_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/substitute-teachers", tags=["預約管理"], response_model=DataResponse)
+@router.get("/options/substitute-teachers", tags=["預約管理"], response_model=DataResponse[List[TeacherOption]])
 async def get_substitute_teacher_options(
     booking_id: str = Query(..., description="預約 ID"),
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
@@ -2855,7 +2855,7 @@ async def get_substitute_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teacher-contracts/{teacher_id}", tags=["預約管理"], response_model=DataResponse)
+@router.get("/options/teacher-contracts/{teacher_id}", tags=["預約管理"], response_model=DataResponse[List[ContractOption]])
 async def get_teacher_contract_options(
     teacher_id: str,
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
@@ -2876,7 +2876,7 @@ async def get_teacher_contract_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teacher-slots/{teacher_id}", tags=["預約管理"], response_model=DataResponse)
+@router.get("/options/teacher-slots/{teacher_id}", tags=["預約管理"], response_model=DataResponse[List[SlotOption]])
 async def get_teacher_slot_options(
     teacher_id: str,
     date_from: Optional[date] = Query(None, description="開始日期"),

--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -924,7 +924,7 @@ async def get_slot_availability(
         raise HTTPException(status_code=500, detail=f"取得時段可用狀態失敗: {str(e)}")
 
 
-@router.get("/my-student-info", tags=["預約管理"])
+@router.get("/my-student-info", tags=["預約管理"], response_model=DataResponse)
 async def get_my_student_info(
     current_user: CurrentUser = Depends(get_current_user)
 ):
@@ -949,7 +949,7 @@ async def get_my_student_info(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/my-contracts", tags=["預約管理"])
+@router.get("/my-contracts", tags=["預約管理"], response_model=DataResponse)
 async def get_my_contracts(
     current_user: CurrentUser = Depends(get_current_user)
 ):
@@ -2490,7 +2490,7 @@ async def batch_delete_bookings_by_ids(
 # 輔助 API：取得下拉選單資料
 # ============================================
 
-@router.get("/options/students", tags=["預約管理"])
+@router.get("/options/students", tags=["預約管理"], response_model=DataResponse)
 async def get_student_options(
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
 ):
@@ -2506,7 +2506,7 @@ async def get_student_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teachers", tags=["預約管理"])
+@router.get("/options/teachers", tags=["預約管理"], response_model=DataResponse)
 async def get_teacher_options(
     student_id: Optional[str] = Query(None, description="學生 ID（用於偏好過濾）"),
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
@@ -2537,7 +2537,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/overlapping-courses", tags=["預約管理"])
+@router.get("/options/overlapping-courses", tags=["預約管理"], response_model=DataResponse)
 async def get_overlapping_course_options(
     student_id: str = Query(..., description="學生 ID"),
     teacher_id: str = Query(..., description="教師 ID"),
@@ -2627,7 +2627,7 @@ async def get_overlapping_course_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/courses", tags=["預約管理"])
+@router.get("/options/courses", tags=["預約管理"], response_model=DataResponse)
 async def get_course_options(
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
 ):
@@ -2643,7 +2643,7 @@ async def get_course_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/student-contracts/{student_id}", tags=["預約管理"])
+@router.get("/options/student-contracts/{student_id}", tags=["預約管理"], response_model=DataResponse)
 async def get_student_contract_options(
     student_id: str,
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
@@ -2696,7 +2696,7 @@ async def get_student_contract_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/substitute-teachers", tags=["預約管理"])
+@router.get("/options/substitute-teachers", tags=["預約管理"], response_model=DataResponse)
 async def get_substitute_teacher_options(
     booking_id: str = Query(..., description="預約 ID"),
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
@@ -2855,7 +2855,7 @@ async def get_substitute_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teacher-contracts/{teacher_id}", tags=["預約管理"])
+@router.get("/options/teacher-contracts/{teacher_id}", tags=["預約管理"], response_model=DataResponse)
 async def get_teacher_contract_options(
     teacher_id: str,
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))
@@ -2876,7 +2876,7 @@ async def get_teacher_contract_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teacher-slots/{teacher_id}", tags=["預約管理"])
+@router.get("/options/teacher-slots/{teacher_id}", tags=["預約管理"], response_model=DataResponse)
 async def get_teacher_slot_options(
     teacher_id: str,
     date_from: Optional[date] = Query(None, description="開始日期"),

--- a/backend/app/api/v1/employees.py
+++ b/backend/app/api/v1/employees.py
@@ -42,7 +42,7 @@ async def enrich_employee(emp: dict) -> dict:
     return emp
 
 
-@router.get("/roles", tags=["員工管理"])
+@router.get("/roles", tags=["員工管理"], response_model=DataResponse)
 async def list_roles_for_employees(
     current_user: CurrentUser = Depends(require_page_permission("employees.list"))
 ):

--- a/backend/app/api/v1/employees.py
+++ b/backend/app/api/v1/employees.py
@@ -2,8 +2,8 @@ from fastapi import APIRouter, Depends, Query, HTTPException
 from app.services.supabase_service import supabase_service
 from app.core.dependencies import get_current_user, CurrentUser, require_page_permission, get_user_employee_id
 from app.schemas.employee import EmployeeCreate, EmployeeUpdate, EmployeeResponse, EmployeeListResponse
-from app.schemas.response import BaseResponse, DataResponse
-from typing import Optional
+from app.schemas.response import BaseResponse, DataResponse, RoleOption
+from typing import Optional, List
 from datetime import datetime
 import math
 import logging
@@ -42,7 +42,7 @@ async def enrich_employee(emp: dict) -> dict:
     return emp
 
 
-@router.get("/roles", tags=["員工管理"], response_model=DataResponse)
+@router.get("/roles", tags=["員工管理"], response_model=DataResponse[List[RoleOption]])
 async def list_roles_for_employees(
     current_user: CurrentUser = Depends(require_page_permission("employees.list"))
 ):

--- a/backend/app/api/v1/google_drive.py
+++ b/backend/app/api/v1/google_drive.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 # ── OAuth 端點 ──
 
-@router.get("/oauth/authorize")
+@router.get("/oauth/authorize", response_model=DataResponse)
 async def get_oauth_authorize_url(
     current_user: CurrentUser = Depends(require_staff),
 ):
@@ -101,7 +101,7 @@ async def oauth_callback(
         return RedirectResponse(url=f"{settings.FRONTEND_URL}/zoom-accounts?google_drive=error")
 
 
-@router.get("/oauth/status")
+@router.get("/oauth/status", response_model=DataResponse)
 async def get_drive_status(
     current_user: CurrentUser = Depends(get_current_user),
 ):

--- a/backend/app/api/v1/student_contracts.py
+++ b/backend/app/api/v1/student_contracts.py
@@ -24,8 +24,8 @@ from app.schemas.contract_addendum import (
     ContractAddendumCreate, ContractAddendumUpdate,
     ContractAddendumResponse, ContractAddendumListResponse,
 )
-from app.schemas.response import BaseResponse, DataResponse, UploadUrlResponse, DownloadUrlResponse
-from typing import Optional
+from app.schemas.response import BaseResponse, DataResponse, UploadUrlResponse, DownloadUrlResponse, StudentOption, CourseOption, TeacherOption
+from typing import Optional, List
 from datetime import datetime
 import math
 import uuid
@@ -160,7 +160,7 @@ async def enrich_contract_with_relations(contract: dict) -> dict:
 
 # ========== Options ==========
 
-@router.get("/options/students", tags=["學生合約管理"], response_model=DataResponse)
+@router.get("/options/students", tags=["學生合約管理"], response_model=DataResponse[List[StudentOption]])
 async def get_student_options(
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
 ):
@@ -176,7 +176,7 @@ async def get_student_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/courses", tags=["學生合約管理"], response_model=DataResponse)
+@router.get("/options/courses", tags=["學生合約管理"], response_model=DataResponse[List[CourseOption]])
 async def get_course_options(
     student_id: Optional[str] = Query(None, description="若提供，只回傳該學生已選修的課程"),
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
@@ -225,7 +225,7 @@ async def get_course_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teachers", tags=["學生合約管理"], response_model=DataResponse)
+@router.get("/options/teachers", tags=["學生合約管理"], response_model=DataResponse[List[TeacherOption]])
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
 ):
@@ -724,7 +724,7 @@ async def delete_student_contract(
 
 # ========== Contract Details CRUD ==========
 
-@router.get("/{contract_id}/details", response_model=DataResponse)
+@router.get("/{contract_id}/details", response_model=DataResponse[List[StudentContractDetailResponse]])
 async def list_contract_details(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
@@ -1024,7 +1024,7 @@ async def delete_contract_detail(
 
 # ========== Leave Records CRUD ==========
 
-@router.get("/{contract_id}/leave-records", response_model=DataResponse)
+@router.get("/{contract_id}/leave-records", response_model=DataResponse[List[StudentContractLeaveRecordResponse]])
 async def list_leave_records(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))

--- a/backend/app/api/v1/student_contracts.py
+++ b/backend/app/api/v1/student_contracts.py
@@ -24,7 +24,7 @@ from app.schemas.contract_addendum import (
     ContractAddendumCreate, ContractAddendumUpdate,
     ContractAddendumResponse, ContractAddendumListResponse,
 )
-from app.schemas.response import BaseResponse, DataResponse
+from app.schemas.response import BaseResponse, DataResponse, UploadUrlResponse, DownloadUrlResponse
 from typing import Optional
 from datetime import datetime
 import math
@@ -160,7 +160,7 @@ async def enrich_contract_with_relations(contract: dict) -> dict:
 
 # ========== Options ==========
 
-@router.get("/options/students", tags=["學生合約管理"])
+@router.get("/options/students", tags=["學生合約管理"], response_model=DataResponse)
 async def get_student_options(
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
 ):
@@ -176,7 +176,7 @@ async def get_student_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/courses", tags=["學生合約管理"])
+@router.get("/options/courses", tags=["學生合約管理"], response_model=DataResponse)
 async def get_course_options(
     student_id: Optional[str] = Query(None, description="若提供，只回傳該學生已選修的課程"),
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
@@ -225,7 +225,7 @@ async def get_course_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teachers", tags=["學生合約管理"])
+@router.get("/options/teachers", tags=["學生合約管理"], response_model=DataResponse)
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
 ):
@@ -724,7 +724,7 @@ async def delete_student_contract(
 
 # ========== Contract Details CRUD ==========
 
-@router.get("/{contract_id}/details")
+@router.get("/{contract_id}/details", response_model=DataResponse)
 async def list_contract_details(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
@@ -779,7 +779,7 @@ async def list_contract_details(
         raise HTTPException(status_code=500, detail=f"取得合約明細失敗: {str(e)}")
 
 
-@router.post("/{contract_id}/details")
+@router.post("/{contract_id}/details", response_model=DataResponse[StudentContractDetailResponse])
 async def create_contract_detail(
     contract_id: str,
     data: StudentContractDetailCreate,
@@ -877,7 +877,7 @@ async def create_contract_detail(
         raise HTTPException(status_code=500, detail=f"新增合約明細失敗: {str(e)}")
 
 
-@router.put("/{contract_id}/details/{detail_id}")
+@router.put("/{contract_id}/details/{detail_id}", response_model=DataResponse[StudentContractDetailResponse])
 async def update_contract_detail(
     contract_id: str,
     detail_id: str,
@@ -1024,7 +1024,7 @@ async def delete_contract_detail(
 
 # ========== Leave Records CRUD ==========
 
-@router.get("/{contract_id}/leave-records")
+@router.get("/{contract_id}/leave-records", response_model=DataResponse)
 async def list_leave_records(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
@@ -1066,7 +1066,7 @@ async def list_leave_records(
         raise HTTPException(status_code=500, detail=f"取得請假紀錄失敗: {str(e)}")
 
 
-@router.post("/{contract_id}/leave-records")
+@router.post("/{contract_id}/leave-records", response_model=DataResponse[StudentContractLeaveRecordResponse])
 async def create_leave_record(
     contract_id: str,
     data: StudentContractLeaveRecordCreate,
@@ -1249,7 +1249,7 @@ class ConfirmUploadRequest(BaseModel):
     file_name: str
 
 
-@router.post("/{contract_id}/upload-url")
+@router.post("/{contract_id}/upload-url", response_model=UploadUrlResponse)
 async def get_student_contract_upload_url(
     contract_id: str,
     file_ext: str = Query("pdf", description="檔案格式 (pdf/docx/doc)"),
@@ -1370,7 +1370,7 @@ async def confirm_student_contract_upload(
         raise HTTPException(status_code=500, detail=f"確認上傳失敗: {str(e)}")
 
 
-@router.get("/{contract_id}/download-url")
+@router.get("/{contract_id}/download-url", response_model=DownloadUrlResponse)
 async def get_student_contract_download_url(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("students.contracts"))
@@ -1749,7 +1749,7 @@ class AddendumConfirmUploadRequest(BaseModel):
     file_name: str
 
 
-@router.post("/{contract_id}/addendums/{addendum_id}/upload-url")
+@router.post("/{contract_id}/addendums/{addendum_id}/upload-url", response_model=UploadUrlResponse)
 async def get_student_addendum_upload_url(
     contract_id: str,
     addendum_id: str,
@@ -1877,7 +1877,7 @@ async def confirm_student_addendum_upload(
         raise HTTPException(status_code=500, detail=f"確認上傳失敗: {str(e)}")
 
 
-@router.get("/{contract_id}/addendums/{addendum_id}/download-url")
+@router.get("/{contract_id}/addendums/{addendum_id}/download-url", response_model=DownloadUrlResponse)
 async def get_student_addendum_download_url(
     contract_id: str,
     addendum_id: str,

--- a/backend/app/api/v1/student_courses.py
+++ b/backend/app/api/v1/student_courses.py
@@ -162,7 +162,7 @@ async def list_student_courses(
         raise HTTPException(status_code=500, detail=f"取得學生選課列表失敗: {str(e)}")
 
 
-@router.get("/by-student/{student_id}")
+@router.get("/by-student/{student_id}", response_model=DataResponse)
 async def get_courses_by_student(
     student_id: str,
     current_user: CurrentUser = Depends(require_page_permission("students.courses"))

--- a/backend/app/api/v1/student_courses.py
+++ b/backend/app/api/v1/student_courses.py
@@ -5,7 +5,7 @@ from app.schemas.student_course import (
     StudentCourseCreate, StudentCourseResponse, StudentCourseListResponse
 )
 from app.schemas.response import BaseResponse, DataResponse
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime
 import math
 
@@ -162,7 +162,7 @@ async def list_student_courses(
         raise HTTPException(status_code=500, detail=f"取得學生選課列表失敗: {str(e)}")
 
 
-@router.get("/by-student/{student_id}", response_model=DataResponse)
+@router.get("/by-student/{student_id}", response_model=DataResponse[List[StudentCourseResponse]])
 async def get_courses_by_student(
     student_id: str,
     current_user: CurrentUser = Depends(require_page_permission("students.courses"))

--- a/backend/app/api/v1/student_teacher_preferences.py
+++ b/backend/app/api/v1/student_teacher_preferences.py
@@ -47,7 +47,7 @@ async def enrich_preference(pref: dict) -> dict:
     return pref
 
 
-@router.get("/options/teachers", tags=["學生教師偏好"])
+@router.get("/options/teachers", tags=["學生教師偏好"], response_model=DataResponse)
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))
 ):
@@ -63,7 +63,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/courses", tags=["學生教師偏好"])
+@router.get("/options/courses", tags=["學生教師偏好"], response_model=DataResponse)
 async def get_course_options(
     student_id: str = Query(..., description="學生 ID"),
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))
@@ -94,7 +94,7 @@ async def get_course_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/allowed-teachers", tags=["學生教師偏好"])
+@router.get("/allowed-teachers", tags=["學生教師偏好"], response_model=DataResponse)
 async def get_allowed_teachers(
     student_id: str = Query(..., description="學生 ID"),
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))
@@ -119,7 +119,7 @@ async def get_allowed_teachers(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("", tags=["學生教師偏好"])
+@router.get("", tags=["學生教師偏好"], response_model=DataResponse)
 async def list_preferences(
     student_id: str = Query(..., description="學生 ID"),
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))
@@ -164,7 +164,7 @@ async def list_preferences(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.post("")
+@router.post("", response_model=DataResponse)
 async def create_preference(
     data: StudentTeacherPreferenceCreate,
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))

--- a/backend/app/api/v1/student_teacher_preferences.py
+++ b/backend/app/api/v1/student_teacher_preferences.py
@@ -6,7 +6,7 @@ from app.schemas.student_teacher_preference import (
     StudentTeacherPreferenceCreate,
     StudentTeacherPreferenceUpdate, StudentTeacherPreferenceResponse
 )
-from app.schemas.response import BaseResponse, DataResponse
+from app.schemas.response import BaseResponse, DataResponse, TeacherOption, CourseOption
 from typing import Optional, List
 
 router = APIRouter(prefix="/student-teacher-preferences", tags=["學生教師偏好"])
@@ -47,7 +47,7 @@ async def enrich_preference(pref: dict) -> dict:
     return pref
 
 
-@router.get("/options/teachers", tags=["學生教師偏好"], response_model=DataResponse)
+@router.get("/options/teachers", tags=["學生教師偏好"], response_model=DataResponse[List[TeacherOption]])
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))
 ):
@@ -63,7 +63,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/courses", tags=["學生教師偏好"], response_model=DataResponse)
+@router.get("/options/courses", tags=["學生教師偏好"], response_model=DataResponse[List[CourseOption]])
 async def get_course_options(
     student_id: str = Query(..., description="學生 ID"),
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))
@@ -94,7 +94,7 @@ async def get_course_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/allowed-teachers", tags=["學生教師偏好"], response_model=DataResponse)
+@router.get("/allowed-teachers", tags=["學生教師偏好"], response_model=DataResponse[List[TeacherOption]])
 async def get_allowed_teachers(
     student_id: str = Query(..., description="學生 ID"),
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))
@@ -119,7 +119,7 @@ async def get_allowed_teachers(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("", tags=["學生教師偏好"], response_model=DataResponse)
+@router.get("", tags=["學生教師偏好"], response_model=DataResponse[List[StudentTeacherPreferenceResponse]])
 async def list_preferences(
     student_id: str = Query(..., description="學生 ID"),
     current_user: CurrentUser = Depends(require_page_permission("students.edit"))

--- a/backend/app/api/v1/students.py
+++ b/backend/app/api/v1/students.py
@@ -6,7 +6,7 @@ from app.schemas.student import (
     ConvertToFormalRequest, ConvertToFormalResponse, ConvertToFormalContractInfo,
 )
 from app.schemas.student_view import StudentViewResponse
-from app.schemas.response import BaseResponse, DataResponse
+from app.schemas.response import BaseResponse, DataResponse, PaginatedResponse
 from typing import Optional
 from datetime import datetime, date
 import math
@@ -371,7 +371,7 @@ async def convert_to_formal(
 # Student Overview — 學生總覽列表 API
 # ============================================
 
-@router.get("/overview/list")
+@router.get("/overview/list", response_model=PaginatedResponse)
 async def list_students_overview(
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),

--- a/backend/app/api/v1/teacher_bonus.py
+++ b/backend/app/api/v1/teacher_bonus.py
@@ -298,7 +298,7 @@ async def delete_teacher_bonus(
 
 # ========== Options ==========
 
-@router.get("/options/teachers")
+@router.get("/options/teachers", response_model=DataResponse)
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("teachers.bonus"))
 ):

--- a/backend/app/api/v1/teacher_bonus.py
+++ b/backend/app/api/v1/teacher_bonus.py
@@ -5,8 +5,8 @@ from app.schemas.teacher_bonus import (
     TeacherBonusCreate, TeacherBonusUpdate,
     TeacherBonusResponse, TeacherBonusListResponse,
 )
-from app.schemas.response import BaseResponse, DataResponse
-from typing import Optional
+from app.schemas.response import BaseResponse, DataResponse, TeacherOption
+from typing import Optional, List
 from datetime import datetime, date
 import math
 
@@ -298,7 +298,7 @@ async def delete_teacher_bonus(
 
 # ========== Options ==========
 
-@router.get("/options/teachers", response_model=DataResponse)
+@router.get("/options/teachers", response_model=DataResponse[List[TeacherOption]])
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("teachers.bonus"))
 ):

--- a/backend/app/api/v1/teacher_contracts.py
+++ b/backend/app/api/v1/teacher_contracts.py
@@ -22,7 +22,7 @@ from app.schemas.contract_addendum import (
     ContractAddendumCreate, ContractAddendumUpdate,
     ContractAddendumResponse, ContractAddendumListResponse,
 )
-from app.schemas.response import BaseResponse, DataResponse
+from app.schemas.response import BaseResponse, DataResponse, UploadUrlResponse, DownloadUrlResponse
 from typing import Optional
 from datetime import datetime
 import math
@@ -151,7 +151,7 @@ async def enrich_contract_with_relations(contract: dict) -> dict:
 CONTRACT_SELECT = "id,contract_no,teacher_id,contract_status,start_date,end_date,employment_type,trial_completed_bonus,trial_to_formal_bonus,work_start_time,work_end_time,notes,created_at,updated_at,contract_file_path,contract_file_name,contract_file_uploaded_at"
 
 
-@router.get("/options/teachers", tags=["教師合約管理"])
+@router.get("/options/teachers", tags=["教師合約管理"], response_model=DataResponse)
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
 ):
@@ -167,7 +167,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/courses", tags=["教師合約管理"])
+@router.get("/options/courses", tags=["教師合約管理"], response_model=DataResponse)
 async def get_course_options(
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
 ):
@@ -646,7 +646,7 @@ async def delete_teacher_contract(
 
 # ========== Contract Details CRUD ==========
 
-@router.get("/{contract_id}/details")
+@router.get("/{contract_id}/details", response_model=DataResponse)
 async def list_contract_details(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
@@ -701,7 +701,7 @@ async def list_contract_details(
         raise HTTPException(status_code=500, detail=f"取得合約明細失敗: {str(e)}")
 
 
-@router.post("/{contract_id}/details")
+@router.post("/{contract_id}/details", response_model=DataResponse[TeacherContractDetailResponse])
 async def create_contract_detail(
     contract_id: str,
     data: TeacherContractDetailCreate,
@@ -783,7 +783,7 @@ async def create_contract_detail(
         raise HTTPException(status_code=500, detail=f"新增合約明細失敗: {str(e)}")
 
 
-@router.put("/{contract_id}/details/{detail_id}")
+@router.put("/{contract_id}/details/{detail_id}", response_model=DataResponse[TeacherContractDetailResponse])
 async def update_contract_detail(
     contract_id: str,
     detail_id: str,
@@ -895,7 +895,7 @@ async def delete_contract_detail(
 
 # ========== Work Schedules CRUD ==========
 
-@router.get("/{contract_id}/work-schedules")
+@router.get("/{contract_id}/work-schedules", response_model=DataResponse)
 async def list_work_schedules(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
@@ -934,7 +934,7 @@ async def list_work_schedules(
         raise HTTPException(status_code=500, detail=f"取得工作時段失敗: {str(e)}")
 
 
-@router.put("/{contract_id}/work-schedules")
+@router.put("/{contract_id}/work-schedules", response_model=DataResponse)
 async def set_work_schedules(
     contract_id: str,
     data: TeacherWorkScheduleBatchSet,
@@ -1097,7 +1097,7 @@ class ConfirmUploadRequest(BaseModel):
     file_name: str
 
 
-@router.post("/{contract_id}/upload-url")
+@router.post("/{contract_id}/upload-url", response_model=UploadUrlResponse)
 async def get_teacher_contract_upload_url(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
@@ -1212,7 +1212,7 @@ async def confirm_teacher_contract_upload(
         raise HTTPException(status_code=500, detail=f"確認上傳失敗: {str(e)}")
 
 
-@router.get("/{contract_id}/download-url")
+@router.get("/{contract_id}/download-url", response_model=DownloadUrlResponse)
 async def get_teacher_contract_download_url(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
@@ -1585,7 +1585,7 @@ class AddendumConfirmUploadRequest(BaseModel):
     file_name: str
 
 
-@router.post("/{contract_id}/addendums/{addendum_id}/upload-url")
+@router.post("/{contract_id}/addendums/{addendum_id}/upload-url", response_model=UploadUrlResponse)
 async def get_teacher_addendum_upload_url(
     contract_id: str,
     addendum_id: str,
@@ -1710,7 +1710,7 @@ async def confirm_teacher_addendum_upload(
         raise HTTPException(status_code=500, detail=f"確認上傳失敗: {str(e)}")
 
 
-@router.get("/{contract_id}/addendums/{addendum_id}/download-url")
+@router.get("/{contract_id}/addendums/{addendum_id}/download-url", response_model=DownloadUrlResponse)
 async def get_teacher_addendum_download_url(
     contract_id: str,
     addendum_id: str,

--- a/backend/app/api/v1/teacher_contracts.py
+++ b/backend/app/api/v1/teacher_contracts.py
@@ -22,8 +22,8 @@ from app.schemas.contract_addendum import (
     ContractAddendumCreate, ContractAddendumUpdate,
     ContractAddendumResponse, ContractAddendumListResponse,
 )
-from app.schemas.response import BaseResponse, DataResponse, UploadUrlResponse, DownloadUrlResponse
-from typing import Optional
+from app.schemas.response import BaseResponse, DataResponse, UploadUrlResponse, DownloadUrlResponse, TeacherOption, CourseOption
+from typing import Optional, List
 from datetime import datetime
 import math
 import uuid
@@ -151,7 +151,7 @@ async def enrich_contract_with_relations(contract: dict) -> dict:
 CONTRACT_SELECT = "id,contract_no,teacher_id,contract_status,start_date,end_date,employment_type,trial_completed_bonus,trial_to_formal_bonus,work_start_time,work_end_time,notes,created_at,updated_at,contract_file_path,contract_file_name,contract_file_uploaded_at"
 
 
-@router.get("/options/teachers", tags=["教師合約管理"], response_model=DataResponse)
+@router.get("/options/teachers", tags=["教師合約管理"], response_model=DataResponse[List[TeacherOption]])
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
 ):
@@ -167,7 +167,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/courses", tags=["教師合約管理"], response_model=DataResponse)
+@router.get("/options/courses", tags=["教師合約管理"], response_model=DataResponse[List[CourseOption]])
 async def get_course_options(
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
 ):
@@ -646,7 +646,7 @@ async def delete_teacher_contract(
 
 # ========== Contract Details CRUD ==========
 
-@router.get("/{contract_id}/details", response_model=DataResponse)
+@router.get("/{contract_id}/details", response_model=DataResponse[List[TeacherContractDetailResponse]])
 async def list_contract_details(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
@@ -895,7 +895,7 @@ async def delete_contract_detail(
 
 # ========== Work Schedules CRUD ==========
 
-@router.get("/{contract_id}/work-schedules", response_model=DataResponse)
+@router.get("/{contract_id}/work-schedules", response_model=DataResponse[List[TeacherWorkScheduleResponse]])
 async def list_work_schedules(
     contract_id: str,
     current_user: CurrentUser = Depends(require_page_permission("teachers.contracts"))
@@ -934,7 +934,7 @@ async def list_work_schedules(
         raise HTTPException(status_code=500, detail=f"取得工作時段失敗: {str(e)}")
 
 
-@router.put("/{contract_id}/work-schedules", response_model=DataResponse)
+@router.put("/{contract_id}/work-schedules", response_model=DataResponse[List[TeacherWorkScheduleResponse]])
 async def set_work_schedules(
     contract_id: str,
     data: TeacherWorkScheduleBatchSet,

--- a/backend/app/api/v1/teacher_details.py
+++ b/backend/app/api/v1/teacher_details.py
@@ -8,7 +8,7 @@ from app.schemas.teacher_detail import (
     TeacherDetailCreate, TeacherDetailUpdate,
     TeacherDetailResponse, TeacherDetailListResponse,
 )
-from app.schemas.response import BaseResponse, DataResponse
+from app.schemas.response import BaseResponse, DataResponse, UploadUrlResponse, DownloadUrlResponse
 from datetime import datetime
 import uuid
 
@@ -184,7 +184,7 @@ class ConfirmUploadRequest(BaseModel):
     file_name: str
 
 
-@router.post("/{detail_id}/upload-url")
+@router.post("/{detail_id}/upload-url", response_model=UploadUrlResponse)
 async def get_teacher_detail_upload_url(
     detail_id: str,
     body: UploadUrlRequest,
@@ -288,7 +288,7 @@ async def confirm_teacher_detail_upload(
         raise HTTPException(status_code=500, detail=f"確認上傳失敗: {str(e)}")
 
 
-@router.get("/{detail_id}/download-url")
+@router.get("/{detail_id}/download-url", response_model=DownloadUrlResponse)
 async def get_teacher_detail_download_url(
     detail_id: str,
     current_user: CurrentUser = Depends(require_page_permission("teachers.details"))

--- a/backend/app/api/v1/teacher_slots.py
+++ b/backend/app/api/v1/teacher_slots.py
@@ -6,8 +6,8 @@ from app.schemas.teacher_slot import (
     TeacherSlotBatchDeleteByIds, TeacherSlotBatchUpdateByIds,
     TeacherSlotUpdate, TeacherSlotResponse, TeacherSlotListResponse
 )
-from app.schemas.response import BaseResponse, DataResponse
-from typing import Optional
+from app.schemas.response import BaseResponse, DataResponse, TeacherOption, ContractOption
+from typing import Optional, List
 from datetime import date, datetime, timedelta
 import math
 
@@ -160,7 +160,7 @@ async def list_teacher_slots(
         raise HTTPException(status_code=500, detail=f"取得教師時段列表失敗: {str(e)}")
 
 
-@router.get("/options/teachers", tags=["教師時段管理"], response_model=DataResponse)
+@router.get("/options/teachers", tags=["教師時段管理"], response_model=DataResponse[List[TeacherOption]])
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("teachers.slots"))
 ):
@@ -176,7 +176,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/my-contracts", tags=["教師時段管理"], response_model=DataResponse)
+@router.get("/my-contracts", tags=["教師時段管理"], response_model=DataResponse[List[ContractOption]])
 async def get_my_contracts(
     current_user: CurrentUser = Depends(require_page_permission("teachers.slots"))
 ):

--- a/backend/app/api/v1/teacher_slots.py
+++ b/backend/app/api/v1/teacher_slots.py
@@ -160,7 +160,7 @@ async def list_teacher_slots(
         raise HTTPException(status_code=500, detail=f"取得教師時段列表失敗: {str(e)}")
 
 
-@router.get("/options/teachers", tags=["教師時段管理"])
+@router.get("/options/teachers", tags=["教師時段管理"], response_model=DataResponse)
 async def get_teacher_options(
     current_user: CurrentUser = Depends(require_page_permission("teachers.slots"))
 ):
@@ -176,7 +176,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/my-contracts", tags=["教師時段管理"])
+@router.get("/my-contracts", tags=["教師時段管理"], response_model=DataResponse)
 async def get_my_contracts(
     current_user: CurrentUser = Depends(require_page_permission("teachers.slots"))
 ):

--- a/backend/app/api/v1/teachers.py
+++ b/backend/app/api/v1/teachers.py
@@ -6,7 +6,7 @@ from app.config import settings
 from app.core.dependencies import get_current_user, CurrentUser, require_staff, require_teacher, require_page_permission, get_user_employee_id
 from app.schemas.teacher import TeacherCreate, TeacherUpdate, TeacherSelfUpdate, TeacherResponse, TeacherListResponse
 from app.schemas.teacher_view import TeacherViewResponse
-from app.schemas.response import BaseResponse, DataResponse
+from app.schemas.response import BaseResponse, DataResponse, PaginatedResponse, UploadUrlResponse
 from typing import Optional
 from datetime import datetime
 import logging
@@ -115,7 +115,7 @@ async def update_teacher_self(
 # （必須在 /{teacher_id} 之前註冊）
 # ============================================
 
-@router.get("/overview/list")
+@router.get("/overview/list", response_model=PaginatedResponse)
 async def list_teachers_overview(
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
@@ -466,7 +466,7 @@ class AvatarConfirmRequest(BaseModel):
     file_name: str
 
 
-@router.post("/{teacher_id}/avatar/upload-url")
+@router.post("/{teacher_id}/avatar/upload-url", response_model=UploadUrlResponse)
 async def get_teacher_avatar_upload_url(
     teacher_id: str,
     body: AvatarUploadUrlRequest,

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -77,6 +77,25 @@ class UserInfo(BaseModel):
     student_id: Optional[str] = Field(None, description="學生 ID")
     employee_id: Optional[str] = Field(None, description="員工 ID")
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "email": "employee@eop-education.com",
+                "role": "employee",
+                "role_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "email_confirmed": True,
+                "created_at": "2026-01-10T08:00:00",
+                "employee_type": "full_time",
+                "permission_level": 5,
+                "must_change_password": False,
+                "teacher_id": None,
+                "student_id": None,
+                "employee_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+            }]
+        }
+    }
+
 class LoginResponse(BaseModel):
     success: bool = True
     message: str = "登入成功"

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -125,8 +125,46 @@ class BookingResponse(BaseModel):
     has_pending_leave: bool = False
     pending_leave_initiator_type: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "booking_no": "BK-20260415-001",
+                "student_id": "660e8400-e29b-41d4-a716-446655440000",
+                "teacher_id": "770e8400-e29b-41d4-a716-446655440000",
+                "course_id": "880e8400-e29b-41d4-a716-446655440000",
+                "student_contract_id": "990e8400-e29b-41d4-a716-446655440000",
+                "teacher_contract_id": "aa0e8400-e29b-41d4-a716-446655440000",
+                "teacher_slot_id": "bb0e8400-e29b-41d4-a716-446655440000",
+                "substitute_detail_id": None,
+                "teacher_hourly_rate": 800.0,
+                "teacher_rate_percentage": None,
+                "booking_status": "confirmed",
+                "booking_date": "2026-04-15",
+                "start_time": "14:00:00",
+                "end_time": "15:00:00",
+                "booking_type": "regular",
+                "is_trial_to_formal": False,
+                "is_overtime": False,
+                "regular_lessons": 2,
+                "overtime_lessons": 0,
+                "overtime_pay": 0.0,
+                "lessons_used": 1,
+                "notes": "學生表現良好",
+                "created_at": "2026-04-10T08:00:00",
+                "updated_at": "2026-04-10T08:00:00",
+                "student_name": "王小明",
+                "teacher_name": "陳美玲",
+                "course_name": "英語日常會話",
+                "student_contract_no": "SC-2026-001",
+                "teacher_contract_no": "TC-2026-001",
+                "substitute_teacher_name": None,
+                "has_pending_leave": False,
+                "pending_leave_initiator_type": None,
+            }]
+        }
+    }
 
 
 class BookingListResponse(BaseModel):
@@ -288,3 +326,22 @@ class SlotAvailabilityResponse(BaseModel):
     slot_start_time: time
     slot_end_time: time
     blocks: List[TimeBlock] = []
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "slot_id": "550e8400-e29b-41d4-a716-446655440000",
+                "slot_date": "2026-04-15",
+                "slot_start_time": "09:00:00",
+                "slot_end_time": "12:00:00",
+                "blocks": [
+                    {"start_time": "09:00:00", "end_time": "09:30:00", "is_available": True, "booking_id": None},
+                    {"start_time": "09:30:00", "end_time": "10:00:00", "is_available": False, "booking_id": "660e8400-e29b-41d4-a716-446655440000"},
+                    {"start_time": "10:00:00", "end_time": "10:30:00", "is_available": False, "booking_id": "660e8400-e29b-41d4-a716-446655440000"},
+                    {"start_time": "10:30:00", "end_time": "11:00:00", "is_available": True, "booking_id": None},
+                    {"start_time": "11:00:00", "end_time": "11:30:00", "is_available": True, "booking_id": None},
+                    {"start_time": "11:30:00", "end_time": "12:00:00", "is_available": True, "booking_id": None},
+                ],
+            }]
+        }
+    }

--- a/backend/app/schemas/contract_addendum.py
+++ b/backend/app/schemas/contract_addendum.py
@@ -65,8 +65,28 @@ class ContractAddendumResponse(BaseModel):
     parent_contract_no: Optional[str] = None
     person_name: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "addendum_no": "AD20260401001",
+                "contract_type": "student",
+                "parent_contract_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "original_end_date": "2026-06-30",
+                "new_end_date": "2027-03-31",
+                "addendum_status": "active",
+                "file_path": "contracts/addendums/AD20260401001.pdf",
+                "file_name": "AD20260401001.pdf",
+                "file_uploaded_at": "2026-04-01T14:00:00",
+                "notes": "合約展延至下學期結束",
+                "created_at": "2026-04-01T10:00:00",
+                "updated_at": "2026-04-01T14:00:00",
+                "parent_contract_no": "SC20260101001",
+                "person_name": "王小明",
+            }]
+        }
+    }
 
 
 class ContractAddendumListResponse(BaseModel):

--- a/backend/app/schemas/course.py
+++ b/backend/app/schemas/course.py
@@ -50,8 +50,21 @@ class CourseResponse(CourseBase):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "course_code": "ENG-CONV-01",
+                "course_name": "英語日常會話",
+                "description": "適合初學者的日常英語會話課程",
+                "duration_minutes": 60,
+                "is_active": True,
+                "created_at": "2026-03-15T10:00:00",
+                "updated_at": "2026-03-15T10:00:00",
+            }]
+        }
+    }
 
 
 class CourseListResponse(BaseModel):

--- a/backend/app/schemas/employee.py
+++ b/backend/app/schemas/employee.py
@@ -72,8 +72,29 @@ class EmployeeResponse(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "employee_no": "E001",
+                "employee_type": "full_time",
+                "name": "林雅婷",
+                "email": "yating.lin@example.com",
+                "phone": "0955123456",
+                "address": "台北市中山區南京東路200號",
+                "hire_date": "2026-01-15",
+                "termination_date": None,
+                "is_active": True,
+                "has_account": True,
+                "role_id": "770e8400-e29b-41d4-a716-446655440000",
+                "role_name": "管理員",
+                "email_verified_at": "2026-01-15T09:00:00",
+                "created_at": "2026-01-15T09:00:00",
+                "updated_at": "2026-01-15T09:00:00",
+            }]
+        }
+    }
 
 
 class EmployeeListResponse(BaseModel):

--- a/backend/app/schemas/leave_record.py
+++ b/backend/app/schemas/leave_record.py
@@ -61,8 +61,36 @@ class LeaveRecordResponse(BaseModel):
     booking_no: Optional[str] = None
     approver_name: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "leave_no": "LV20260410001",
+                "initiator_type": "student",
+                "initiator_student_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "initiator_teacher_id": None,
+                "booking_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                "leave_date": "2026-04-15",
+                "start_time": "14:00:00",
+                "end_time": "15:00:00",
+                "reason": "身體不適，需要請假一次",
+                "leave_status": "approved",
+                "approver_id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+                "approved_at": "2026-04-14T10:30:00",
+                "rejection_reason": None,
+                "created_at": "2026-04-14T09:00:00",
+                "updated_at": "2026-04-14T10:30:00",
+                "leave_type": "normal",
+                "deduct_lesson": False,
+                "emergency_quota": 3,
+                "used_emergency_count": 0,
+                "initiator_name": "王小明",
+                "booking_no": "BK20260415001",
+                "approver_name": "張主任",
+            }]
+        }
+    }
 
 
 class LeaveRecordListResponse(BaseModel):

--- a/backend/app/schemas/page_permission.py
+++ b/backend/app/schemas/page_permission.py
@@ -101,8 +101,22 @@ class PageResponse(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "key": "booking_management",
+                "name": "預約管理",
+                "description": "學生預約課程管理頁面",
+                "parent_key": "dashboard",
+                "sort_order": 3,
+                "is_active": True,
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-03-15T10:00:00",
+            }]
+        }
+    }
 
 
 class PageListResponse(BaseModel):
@@ -122,6 +136,26 @@ class RolePagesResponse(BaseModel):
     success: bool = True
     role_id: str
     pages: List[PageResponse] = []
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "success": True,
+                "role_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "pages": [{
+                    "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                    "key": "booking_management",
+                    "name": "預約管理",
+                    "description": "學生預約課程管理頁面",
+                    "parent_key": "dashboard",
+                    "sort_order": 3,
+                    "is_active": True,
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-03-15T10:00:00",
+                }],
+            }]
+        }
+    }
 
 
 class RolePagesBatchSet(BaseModel):
@@ -153,12 +187,42 @@ class UserPageOverrideItem(BaseModel):
     access_type: str
     created_at: Optional[datetime] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "page_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "page_key": "booking_management",
+                "page_name": "預約管理",
+                "access_type": "grant",
+                "created_at": "2026-03-15T10:00:00",
+            }]
+        }
+    }
+
 
 class UserPageOverridesResponse(BaseModel):
     """用戶覆寫回應"""
     success: bool = True
     user_id: str
     overrides: List[UserPageOverrideItem] = []
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "success": True,
+                "user_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "overrides": [{
+                    "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                    "page_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                    "page_key": "booking_management",
+                    "page_name": "預約管理",
+                    "access_type": "grant",
+                    "created_at": "2026-03-15T10:00:00",
+                }],
+            }]
+        }
+    }
 
 
 class UserPageOverrideEntry(BaseModel):
@@ -194,6 +258,19 @@ class RoleInfo(BaseModel):
     is_system: bool = False
     page_count: int = 0
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "key": "senior_teacher",
+                "name": "資深教師",
+                "description": "具備進階排課與學生管理權限的教師角色",
+                "is_system": False,
+                "page_count": 8,
+            }]
+        }
+    }
+
 
 class RoleListResponse(BaseModel):
     """角色列表回應"""
@@ -209,3 +286,24 @@ class MyPermissionsResponse(BaseModel):
     role: str
     page_keys: List[str] = []
     pages: List[PageResponse] = []
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "success": True,
+                "role": "employee",
+                "page_keys": ["dashboard", "booking_management", "student_management", "teacher_management"],
+                "pages": [{
+                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "key": "dashboard",
+                    "name": "儀表板",
+                    "description": "系統總覽",
+                    "parent_key": None,
+                    "sort_order": 1,
+                    "is_active": True,
+                    "created_at": "2026-01-01T00:00:00",
+                    "updated_at": "2026-01-01T00:00:00",
+                }],
+            }]
+        }
+    }

--- a/backend/app/schemas/response.py
+++ b/backend/app/schemas/response.py
@@ -23,3 +23,38 @@ class PaginatedResponse(BaseResponse, Generic[T]):
     page: int = 1
     per_page: int = 20
     total_pages: int = 0
+
+
+# ============================================================
+# 共用：檔案上傳/下載
+# ============================================================
+
+class UploadUrlResponse(BaseResponse):
+    """Presigned upload URL 回應"""
+    upload_url: str
+    storage_path: str
+    content_type: str
+    max_size_bytes: int = 10485760  # 10MB
+
+class DownloadUrlResponse(BaseResponse):
+    """Signed download URL 回應"""
+    download_url: str
+    file_name: str = ""
+
+
+# ============================================================
+# 共用：告警
+# ============================================================
+
+class AlertListResponse(BaseResponse):
+    """告警列表"""
+    data: List[Any] = []
+    total: int = 0
+    page: int = 1
+    per_page: int = 20
+    total_pages: int = 0
+    unread_count: int = 0
+
+class UnreadCountResponse(BaseResponse):
+    """未讀數量"""
+    count: int = 0

--- a/backend/app/schemas/response.py
+++ b/backend/app/schemas/response.py
@@ -36,10 +36,34 @@ class UploadUrlResponse(BaseResponse):
     content_type: str
     max_size_bytes: int = 10485760  # 10MB
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "success": True,
+                "message": "操作成功",
+                "upload_url": "https://s3.amazonaws.com/eop-bucket/upload?X-Amz-Signature=abc123",
+                "storage_path": "contracts/SC20260101001.pdf",
+                "content_type": "application/pdf",
+                "max_size_bytes": 10485760,
+            }]
+        }
+    }
+
 class DownloadUrlResponse(BaseResponse):
     """Signed download URL 回應"""
     download_url: str
     file_name: str = ""
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "success": True,
+                "message": "操作成功",
+                "download_url": "https://s3.amazonaws.com/eop-bucket/contracts/SC20260101001.pdf?X-Amz-Signature=abc123",
+                "file_name": "SC20260101001.pdf",
+            }]
+        }
+    }
 
 
 # ============================================================
@@ -58,3 +82,124 @@ class AlertListResponse(BaseResponse):
 class UnreadCountResponse(BaseResponse):
     """未讀數量"""
     count: int = 0
+
+
+# ============================================================
+# 共用：下拉選單 Option 型別
+# ============================================================
+
+class StudentOption(BaseModel):
+    """學生下拉選項"""
+    id: str
+    student_no: str
+    name: str
+    student_type: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "student_no": "S001",
+                "name": "王小明",
+                "student_type": "formal",
+            }]
+        }
+    }
+
+class TeacherOption(BaseModel):
+    """教師下拉選項"""
+    id: str
+    teacher_no: str
+    name: str
+    teacher_level: Optional[int] = None
+    is_preferred: Optional[bool] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "teacher_no": "T001",
+                "name": "陳老師",
+                "teacher_level": 3,
+                "is_preferred": True,
+            }]
+        }
+    }
+
+class CourseOption(BaseModel):
+    """課程下拉選項"""
+    id: str
+    course_code: Optional[str] = None
+    course_name: str
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "course_code": "ENG-A1",
+                "course_name": "英語初級會話",
+            }]
+        }
+    }
+
+class ContractOption(BaseModel):
+    """合約下拉選項"""
+    id: str
+    contract_no: str
+    remaining_lessons: Optional[int] = None
+    course_id: Optional[str] = None
+    course_ids: Optional[List[str]] = None
+    course_name: Optional[str] = None
+    created_at: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "contract_no": "SC20260101001",
+                "remaining_lessons": 18,
+                "course_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "course_ids": ["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
+                "course_name": "英語初級會話",
+                "created_at": "2026-03-15T10:00:00",
+            }]
+        }
+    }
+
+class RoleOption(BaseModel):
+    """角色下拉選項"""
+    id: str
+    key: str
+    name: str
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "key": "senior_teacher",
+                "name": "資深教師",
+            }]
+        }
+    }
+
+class SlotOption(BaseModel):
+    """教師時段下拉選項"""
+    id: str
+    slot_date: Optional[str] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    teacher_contract_id: Optional[str] = None
+    is_booked: Optional[bool] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "slot_date": "2026-04-15",
+                "start_time": "14:00",
+                "end_time": "15:00",
+                "teacher_contract_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "is_booked": False,
+            }]
+        }
+    }

--- a/backend/app/schemas/student.py
+++ b/backend/app/schemas/student.py
@@ -74,8 +74,29 @@ class StudentResponse(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "student_no": "EOPS001",
+                "name": "王小明",
+                "eng_name": "Ming",
+                "email": "xiaoming.wang@example.com",
+                "phone": "0912345678",
+                "address": "台北市大安區忠孝東路100號",
+                "birth_date": "2015-03-15",
+                "id_number": None,
+                "student_type": "formal",
+                "student_status": "formal",
+                "is_active": True,
+                "google_drive_folder_id": None,
+                "email_verified_at": "2026-03-01T09:00:00",
+                "created_at": "2026-03-01T09:00:00",
+                "updated_at": "2026-03-01T09:00:00",
+            }]
+        }
+    }
 
 
 class StudentListResponse(BaseModel):
@@ -127,8 +148,23 @@ class ConvertToFormalContractInfo(BaseModel):
     notes: Optional[str] = None
     created_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "660e8400-e29b-41d4-a716-446655440000",
+                "contract_no": "SC-2026-001",
+                "student_id": "550e8400-e29b-41d4-a716-446655440000",
+                "contract_status": "active",
+                "start_date": "2026-02-01",
+                "end_date": "2026-07-31",
+                "total_lessons": 24,
+                "remaining_lessons": 24,
+                "notes": None,
+                "created_at": "2026-02-01T10:00:00",
+            }]
+        }
+    }
 
 
 class ConvertToFormalResponse(BaseModel):
@@ -139,3 +175,38 @@ class ConvertToFormalResponse(BaseModel):
     contract: ConvertToFormalContractInfo
     bonus_recorded: bool = False
     bonus_amount: Optional[float] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "success": True,
+                "message": "轉正成功",
+                "student": {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "student_no": "EOPS001",
+                    "name": "王小明",
+                    "eng_name": "Ming",
+                    "email": "xiaoming.wang@example.com",
+                    "phone": "0912345678",
+                    "student_type": "formal",
+                    "student_status": "formal",
+                    "is_active": True,
+                    "created_at": "2026-03-01T09:00:00",
+                    "updated_at": "2026-03-01T09:00:00",
+                },
+                "contract": {
+                    "id": "660e8400-e29b-41d4-a716-446655440000",
+                    "contract_no": "SC-2026-001",
+                    "student_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "contract_status": "active",
+                    "start_date": "2026-02-01",
+                    "end_date": "2026-07-31",
+                    "total_lessons": 24,
+                    "remaining_lessons": 24,
+                    "created_at": "2026-02-01T10:00:00",
+                },
+                "bonus_recorded": True,
+                "bonus_amount": 500.0,
+            }]
+        }
+    }

--- a/backend/app/schemas/student_contract.py
+++ b/backend/app/schemas/student_contract.py
@@ -77,8 +77,23 @@ class StudentContractDetailResponse(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "student_contract_id": "660e8400-e29b-41d4-a716-446655440000",
+                "detail_type": "lesson_price",
+                "course_id": "770e8400-e29b-41d4-a716-446655440000",
+                "course_name": "英語日常會話",
+                "description": "英語會話課程單價",
+                "amount": 1500.0,
+                "notes": None,
+                "created_at": "2026-03-01T10:00:00",
+                "updated_at": "2026-03-01T10:00:00",
+            }]
+        }
+    }
 
 
 # ========== Leave Record Schemas ==========
@@ -106,8 +121,18 @@ class StudentContractLeaveRecordResponse(BaseModel):
     reason: Optional[str] = None
     created_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "student_contract_id": "660e8400-e29b-41d4-a716-446655440000",
+                "leave_date": "2026-04-20",
+                "reason": "家庭旅遊",
+                "created_at": "2026-04-15T14:00:00",
+            }]
+        }
+    }
 
 
 # ========== Contract Schemas ==========
@@ -201,8 +226,56 @@ class StudentContractResponse(BaseModel):
     # 附約
     addendums: list[dict] = []
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "contract_no": "SC-2026-001",
+                "student_id": "660e8400-e29b-41d4-a716-446655440000",
+                "contract_status": "active",
+                "start_date": "2026-03-01",
+                "end_date": "2026-08-31",
+                "total_lessons": 48,
+                "remaining_lessons": 40,
+                "total_amount": 72000.0,
+                "total_leave_allowed": 10,
+                "used_leave_count": 1,
+                "used_emergency_leave_count": 0,
+                "emergency_leave_quota": 10,
+                "is_recurring": True,
+                "notes": None,
+                "created_at": "2026-03-01T10:00:00",
+                "updated_at": "2026-03-15T14:00:00",
+                "contract_file_path": None,
+                "contract_file_name": None,
+                "contract_file_uploaded_at": None,
+                "student_name": "王小明",
+                "student_phone": "0912345678",
+                "student_id_number": None,
+                "details": [{
+                    "id": "770e8400-e29b-41d4-a716-446655440000",
+                    "student_contract_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "detail_type": "lesson_price",
+                    "course_id": "880e8400-e29b-41d4-a716-446655440000",
+                    "course_name": "英語日常會話",
+                    "description": "英語會話課程單價",
+                    "amount": 1500.0,
+                    "notes": None,
+                    "created_at": "2026-03-01T10:00:00",
+                    "updated_at": "2026-03-01T10:00:00",
+                }],
+                "leave_records": [{
+                    "id": "990e8400-e29b-41d4-a716-446655440000",
+                    "student_contract_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "leave_date": "2026-04-20",
+                    "reason": "家庭旅遊",
+                    "created_at": "2026-04-15T14:00:00",
+                }],
+                "addendums": [],
+            }]
+        }
+    }
 
 
 class StudentContractListResponse(BaseModel):

--- a/backend/app/schemas/student_course.py
+++ b/backend/app/schemas/student_course.py
@@ -29,8 +29,21 @@ class StudentCourseResponse(BaseModel):
     enrolled_at: Optional[datetime] = None
     created_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "student_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "course_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                "course_code": "ENG-A1",
+                "course_name": "英語初級會話",
+                "student_name": "王小明",
+                "enrolled_at": "2026-03-01T10:00:00",
+                "created_at": "2026-03-01T10:00:00",
+            }]
+        }
+    }
 
 
 class StudentCourseListResponse(BaseModel):

--- a/backend/app/schemas/student_teacher_preference.py
+++ b/backend/app/schemas/student_teacher_preference.py
@@ -54,5 +54,20 @@ class StudentTeacherPreferenceResponse(BaseModel):
     course_name: Optional[str] = None
     primary_teacher_name: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "student_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "course_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                "min_teacher_level": 3,
+                "primary_teacher_id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+                "created_at": "2026-03-15T10:00:00",
+                "updated_at": "2026-03-15T10:00:00",
+                "student_name": "王小明",
+                "course_name": "英語初級會話",
+                "primary_teacher_name": "陳老師",
+            }]
+        }
+    }

--- a/backend/app/schemas/student_view.py
+++ b/backend/app/schemas/student_view.py
@@ -21,11 +21,40 @@ class StudentBasicInfo(BaseModel):
     email_verified_at: Optional[datetime] = None
     created_at: Optional[datetime] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "student_no": "S001",
+                "name": "王小明",
+                "eng_name": "Ming Wang",
+                "email": "student@eop-education.com",
+                "phone": "0912345678",
+                "address": "台北市大安區忠孝東路100號",
+                "birth_date": "2010-05-15",
+                "student_type": "formal",
+                "is_active": True,
+                "email_verified_at": "2026-01-20T10:00:00",
+                "created_at": "2026-01-15T09:00:00",
+            }]
+        }
+    }
+
 
 class StudentAccountInfo(BaseModel):
     has_account: bool = False
     is_active: Optional[bool] = None
     role: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "has_account": True,
+                "is_active": True,
+                "role": "student",
+            }]
+        }
+    }
 
 
 class StudentLineBinding(BaseModel):
@@ -33,6 +62,17 @@ class StudentLineBinding(BaseModel):
     line_display_name: Optional[str] = None
     line_picture_url: Optional[str] = None
     binding_status: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "bound": True,
+                "line_display_name": "小明",
+                "line_picture_url": "https://profile.line-scdn.net/abc123",
+                "binding_status": "active",
+            }]
+        }
+    }
 
 
 class StudentContractSummary(BaseModel):
@@ -52,6 +92,27 @@ class StudentContractSummary(BaseModel):
     teachers: list[str] = []
     addendum_count: int = 0
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "contract_no": "SC20260101001",
+                "contract_status": "active",
+                "start_date": "2026-01-01",
+                "end_date": "2026-12-31",
+                "total_lessons": 48,
+                "remaining_lessons": 30,
+                "total_amount": 96000.0,
+                "total_leave_allowed": 4,
+                "used_leave_count": 1,
+                "used_emergency_leave_count": 0,
+                "is_recurring": False,
+                "teachers": ["陳老師", "李老師"],
+                "addendum_count": 0,
+            }]
+        }
+    }
+
 
 class StudentBookingSummary(BaseModel):
     id: str
@@ -63,6 +124,21 @@ class StudentBookingSummary(BaseModel):
     teacher_name: Optional[str] = None
     course_name: Optional[str] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "booking_date": "2026-04-15",
+                "start_time": "14:00",
+                "end_time": "15:00",
+                "booking_status": "confirmed",
+                "booking_type": "regular",
+                "teacher_name": "陳老師",
+                "course_name": "英語初級會話",
+            }]
+        }
+    }
+
 
 class StudentCourseSummary(BaseModel):
     id: str
@@ -71,12 +147,35 @@ class StudentCourseSummary(BaseModel):
     course_code: Optional[str] = None
     enrolled_at: Optional[datetime] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "course_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "course_name": "英語初級會話",
+                "course_code": "ENG-A1",
+                "enrolled_at": "2026-03-01T10:00:00",
+            }]
+        }
+    }
+
 
 class StudentPreferenceSummary(BaseModel):
     id: str
     course_name: Optional[str] = None
     min_teacher_level: Optional[int] = None
     primary_teacher_name: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "course_name": "英語初級會話",
+                "min_teacher_level": 3,
+                "primary_teacher_name": "陳老師",
+            }]
+        }
+    }
 
 
 class StudentLeaveSummary(BaseModel):
@@ -86,6 +185,19 @@ class StudentLeaveSummary(BaseModel):
     leave_type: Optional[str] = None
     reason: Optional[str] = None
     booking_date: Optional[date] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "leave_date": "2026-04-15",
+                "leave_status": "approved",
+                "leave_type": "normal",
+                "reason": "身體不適",
+                "booking_date": "2026-04-15",
+            }]
+        }
+    }
 
 
 class StudentStats(BaseModel):
@@ -99,6 +211,23 @@ class StudentStats(BaseModel):
     total_remaining_lessons: int = 0
     total_leaves_used: int = 0
     total_courses_enrolled: int = 0
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "total_bookings": 25,
+                "completed_bookings": 18,
+                "cancelled_bookings": 2,
+                "pending_bookings": 1,
+                "upcoming_bookings": 4,
+                "total_contracts": 2,
+                "active_contracts": 1,
+                "total_remaining_lessons": 30,
+                "total_leaves_used": 1,
+                "total_courses_enrolled": 2,
+            }]
+        }
+    }
 
 
 # ============================================
@@ -115,3 +244,94 @@ class StudentViewResponse(BaseModel):
     teacher_preferences: list[StudentPreferenceSummary] = []
     leave_records_recent: list[StudentLeaveSummary] = []
     stats: StudentStats
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "student": {
+                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "student_no": "S001",
+                    "name": "王小明",
+                    "eng_name": "Ming Wang",
+                    "email": "student@eop-education.com",
+                    "phone": "0912345678",
+                    "address": "台北市大安區忠孝東路100號",
+                    "birth_date": "2010-05-15",
+                    "student_type": "formal",
+                    "is_active": True,
+                    "email_verified_at": "2026-01-20T10:00:00",
+                    "created_at": "2026-01-15T09:00:00",
+                },
+                "account": {
+                    "has_account": True,
+                    "is_active": True,
+                    "role": "student",
+                },
+                "line_binding": {
+                    "bound": True,
+                    "line_display_name": "小明",
+                    "line_picture_url": "https://profile.line-scdn.net/abc123",
+                    "binding_status": "active",
+                },
+                "contracts": [{
+                    "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                    "contract_no": "SC20260101001",
+                    "contract_status": "active",
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-12-31",
+                    "total_lessons": 48,
+                    "remaining_lessons": 30,
+                    "total_amount": 96000.0,
+                    "total_leave_allowed": 4,
+                    "used_leave_count": 1,
+                    "used_emergency_leave_count": 0,
+                    "is_recurring": False,
+                    "teachers": ["陳老師"],
+                    "addendum_count": 0,
+                }],
+                "bookings_recent": [{
+                    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                    "booking_date": "2026-04-15",
+                    "start_time": "14:00",
+                    "end_time": "15:00",
+                    "booking_status": "confirmed",
+                    "booking_type": "regular",
+                    "teacher_name": "陳老師",
+                    "course_name": "英語初級會話",
+                }],
+                "courses": [{
+                    "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+                    "course_id": "e5f6a7b8-c9d0-1234-efab-345678901234",
+                    "course_name": "英語初級會話",
+                    "course_code": "ENG-A1",
+                    "enrolled_at": "2026-03-01T10:00:00",
+                }],
+                "teacher_preferences": [{
+                    "id": "f6a7b8c9-d0e1-2345-fabc-456789012345",
+                    "course_name": "英語初級會話",
+                    "min_teacher_level": 3,
+                    "primary_teacher_name": "陳老師",
+                }],
+                "leave_records_recent": [{
+                    "id": "a7b8c9d0-e1f2-3456-abcd-567890123456",
+                    "leave_date": "2026-04-10",
+                    "leave_status": "approved",
+                    "leave_type": "normal",
+                    "reason": "身體不適",
+                    "booking_date": "2026-04-10",
+                }],
+                "stats": {
+                    "total_bookings": 25,
+                    "completed_bookings": 18,
+                    "cancelled_bookings": 2,
+                    "pending_bookings": 1,
+                    "upcoming_bookings": 4,
+                    "total_contracts": 2,
+                    "active_contracts": 1,
+                    "total_remaining_lessons": 30,
+                    "total_leaves_used": 1,
+                    "total_courses_enrolled": 2,
+                },
+            }]
+        }
+    }

--- a/backend/app/schemas/substitute_detail.py
+++ b/backend/app/schemas/substitute_detail.py
@@ -37,8 +37,26 @@ class SubstituteDetailResponse(BaseModel):
     booking_no: Optional[str] = None
     original_teacher_name: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "booking_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "substitute_teacher_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                "substitute_contract_id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+                "substitute_hourly_rate": 800.0,
+                "reason": "原教師臨時請假，安排代課",
+                "approved_by": "e5f6a7b8-c9d0-1234-efab-345678901234",
+                "approved_at": "2026-04-10T11:00:00",
+                "created_at": "2026-04-10T10:00:00",
+                "updated_at": "2026-04-10T11:00:00",
+                "substitute_teacher_name": "李老師",
+                "booking_no": "BK20260412001",
+                "original_teacher_name": "陳老師",
+            }]
+        }
+    }
 
 
 class SubstituteDetailListResponse(BaseModel):

--- a/backend/app/schemas/teacher.py
+++ b/backend/app/schemas/teacher.py
@@ -81,8 +81,26 @@ class TeacherResponse(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "teacher_no": "EOPT001",
+                "name": "陳美玲",
+                "email": "meiling.chen@example.com",
+                "phone": "0933456789",
+                "address": "台北市信義區松仁路50號",
+                "bio": "英語教學經驗十年，擅長兒童美語與會話教學",
+                "avatar_url": None,
+                "teacher_level": 2,
+                "is_active": True,
+                "email_verified_at": "2026-02-15T08:30:00",
+                "created_at": "2026-02-15T08:30:00",
+                "updated_at": "2026-02-15T08:30:00",
+            }]
+        }
+    }
 
 
 class TeacherListResponse(BaseModel):

--- a/backend/app/schemas/teacher_bonus.py
+++ b/backend/app/schemas/teacher_bonus.py
@@ -86,8 +86,27 @@ class TeacherBonusResponse(BaseModel):
     teacher_name: Optional[str] = None
     student_name: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "teacher_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "bonus_type": "trial_to_formal",
+                "amount": 500.0,
+                "bonus_date": "2026-04-10",
+                "description": "學生王小明試上轉正獎金",
+                "related_student_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                "related_booking_id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+                "notes": "已確認轉正",
+                "created_at": "2026-04-10T09:00:00",
+                "created_by": "e5f6a7b8-c9d0-1234-efab-345678901234",
+                "updated_at": "2026-04-10T09:00:00",
+                "teacher_name": "陳老師",
+                "student_name": "王小明",
+            }]
+        }
+    }
 
 
 class TeacherBonusListResponse(BaseModel):

--- a/backend/app/schemas/teacher_contract.py
+++ b/backend/app/schemas/teacher_contract.py
@@ -59,8 +59,21 @@ class TeacherWorkScheduleResponse(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "teacher_contract_id": "660e8400-e29b-41d4-a716-446655440000",
+                "weekday": 1,
+                "start_time": "09:00:00",
+                "end_time": "12:00:00",
+                "notes": "週二上午時段",
+                "created_at": "2026-03-01T10:00:00",
+                "updated_at": "2026-03-01T10:00:00",
+            }]
+        }
+    }
 
 
 class ContractStatus(str, Enum):
@@ -142,8 +155,23 @@ class TeacherContractDetailResponse(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "teacher_contract_id": "660e8400-e29b-41d4-a716-446655440000",
+                "detail_type": "course_rate",
+                "course_id": "770e8400-e29b-41d4-a716-446655440000",
+                "course_name": "英語日常會話",
+                "description": "英語會話課時薪",
+                "amount": 800.0,
+                "notes": None,
+                "created_at": "2026-03-01T10:00:00",
+                "updated_at": "2026-03-01T10:00:00",
+            }]
+        }
+    }
 
 
 # ========== Contract Schemas ==========
@@ -235,8 +263,55 @@ class TeacherContractResponse(BaseModel):
     # 附約
     addendums: list[dict] = []
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "contract_no": "TC-2026-001",
+                "teacher_id": "660e8400-e29b-41d4-a716-446655440000",
+                "contract_status": "active",
+                "start_date": "2026-03-01",
+                "end_date": "2026-08-31",
+                "employment_type": "hourly",
+                "trial_completed_bonus": 200.0,
+                "trial_to_formal_bonus": 500.0,
+                "work_start_time": None,
+                "work_end_time": None,
+                "notes": None,
+                "created_at": "2026-03-01T10:00:00",
+                "updated_at": "2026-03-01T10:00:00",
+                "contract_file_path": None,
+                "contract_file_name": None,
+                "contract_file_uploaded_at": None,
+                "teacher_name": "陳美玲",
+                "details": [{
+                    "id": "770e8400-e29b-41d4-a716-446655440000",
+                    "teacher_contract_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "detail_type": "course_rate",
+                    "course_id": "880e8400-e29b-41d4-a716-446655440000",
+                    "course_name": "英語日常會話",
+                    "description": "英語會話課時薪",
+                    "amount": 800.0,
+                    "notes": None,
+                    "created_at": "2026-03-01T10:00:00",
+                    "updated_at": "2026-03-01T10:00:00",
+                }],
+                "total_amount": 800.0,
+                "work_schedules": [{
+                    "id": "990e8400-e29b-41d4-a716-446655440000",
+                    "teacher_contract_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "weekday": 1,
+                    "start_time": "09:00:00",
+                    "end_time": "12:00:00",
+                    "notes": "週二上午時段",
+                    "created_at": "2026-03-01T10:00:00",
+                    "updated_at": "2026-03-01T10:00:00",
+                }],
+                "addendums": [],
+            }]
+        }
+    }
 
 
 class TeacherContractListResponse(BaseModel):

--- a/backend/app/schemas/teacher_detail.py
+++ b/backend/app/schemas/teacher_detail.py
@@ -61,8 +61,23 @@ class TeacherDetailResponse(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "teacher_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "detail_type": "certificate",
+                "content": "TESOL 國際英語教學證照",
+                "issue_date": "2024-06-15",
+                "expiry_date": "2027-06-15",
+                "file_path": "teachers/b2c3d4e5/certificates/tesol.pdf",
+                "file_name": "tesol.pdf",
+                "created_at": "2026-03-15T10:00:00",
+                "updated_at": "2026-03-15T10:00:00",
+            }]
+        }
+    }
 
 
 class TeacherDetailListResponse(BaseModel):

--- a/backend/app/schemas/teacher_slot.py
+++ b/backend/app/schemas/teacher_slot.py
@@ -207,8 +207,27 @@ class TeacherSlotResponse(BaseModel):
     teacher_no: Optional[str] = None
     teacher_contract_no: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "teacher_id": "660e8400-e29b-41d4-a716-446655440000",
+                "teacher_contract_id": "770e8400-e29b-41d4-a716-446655440000",
+                "slot_date": "2026-04-15",
+                "start_time": "09:00:00",
+                "end_time": "12:00:00",
+                "is_available": True,
+                "is_booked": False,
+                "notes": None,
+                "created_at": "2026-04-01T08:00:00",
+                "updated_at": "2026-04-01T08:00:00",
+                "teacher_name": "陳美玲",
+                "teacher_no": "EOPT001",
+                "teacher_contract_no": "TC-2026-001",
+            }]
+        }
+    }
 
 
 class TeacherSlotListResponse(BaseModel):

--- a/backend/app/schemas/teacher_view.py
+++ b/backend/app/schemas/teacher_view.py
@@ -17,11 +17,40 @@ class TeacherBasicInfo(BaseModel):
     email_verified_at: Optional[datetime] = None
     created_at: Optional[datetime] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "teacher_no": "T001",
+                "name": "陳老師",
+                "email": "teacher@eop-education.com",
+                "phone": "0923456789",
+                "address": "台北市信義區松仁路50號",
+                "bio": "10年英語教學經驗，專攻兒童英語與會話訓練",
+                "avatar_url": "https://s3.amazonaws.com/eop/avatars/teacher001.jpg",
+                "teacher_level": 3,
+                "is_active": True,
+                "email_verified_at": "2026-01-10T10:00:00",
+                "created_at": "2026-01-05T09:00:00",
+            }]
+        }
+    }
+
 
 class TeacherAccountInfo(BaseModel):
     has_account: bool = False
     is_active: Optional[bool] = None
     role: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "has_account": True,
+                "is_active": True,
+                "role": "teacher",
+            }]
+        }
+    }
 
 
 class TeacherLineBinding(BaseModel):
@@ -29,6 +58,17 @@ class TeacherLineBinding(BaseModel):
     line_display_name: Optional[str] = None
     line_picture_url: Optional[str] = None
     binding_status: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "bound": True,
+                "line_display_name": "陳老師",
+                "line_picture_url": "https://profile.line-scdn.net/def456",
+                "binding_status": "active",
+            }]
+        }
+    }
 
 
 class TeacherContractSummary(BaseModel):
@@ -41,6 +81,21 @@ class TeacherContractSummary(BaseModel):
     notes: Optional[str] = None
     addendum_count: int = 0
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "contract_no": "TC20260101001",
+                "contract_status": "active",
+                "start_date": "2026-01-01",
+                "end_date": "2026-12-31",
+                "employment_type": "part_time",
+                "notes": "每週固定排課 12 小時",
+                "addendum_count": 0,
+            }]
+        }
+    }
+
 
 class TeacherBookingSummary(BaseModel):
     id: str
@@ -52,6 +107,21 @@ class TeacherBookingSummary(BaseModel):
     student_name: Optional[str] = None
     course_name: Optional[str] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "booking_date": "2026-04-15",
+                "start_time": "14:00",
+                "end_time": "15:00",
+                "booking_status": "confirmed",
+                "booking_type": "regular",
+                "student_name": "王小明",
+                "course_name": "英語初級會話",
+            }]
+        }
+    }
+
 
 class TeacherBonusSummary(BaseModel):
     id: str
@@ -61,6 +131,19 @@ class TeacherBonusSummary(BaseModel):
     description: Optional[str] = None
     student_name: Optional[str] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "bonus_type": "trial_to_formal",
+                "amount": 500.0,
+                "bonus_date": "2026-04-10",
+                "description": "學生王小明試上轉正獎金",
+                "student_name": "王小明",
+            }]
+        }
+    }
+
 
 class TeacherWorkScheduleSummary(BaseModel):
     id: str
@@ -68,6 +151,18 @@ class TeacherWorkScheduleSummary(BaseModel):
     start_time: Optional[str] = None
     end_time: Optional[str] = None
     notes: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "weekday": 1,
+                "start_time": "09:00",
+                "end_time": "12:00",
+                "notes": "週一上午固定時段",
+            }]
+        }
+    }
 
 
 class TeacherStats(BaseModel):
@@ -82,6 +177,23 @@ class TeacherStats(BaseModel):
     total_bonus_count: int = 0
     total_students_taught: int = 0
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "total_bookings": 120,
+                "completed_bookings": 95,
+                "cancelled_bookings": 5,
+                "pending_bookings": 3,
+                "upcoming_bookings": 17,
+                "total_contracts": 2,
+                "active_contracts": 1,
+                "total_bonus_amount": 15000.0,
+                "total_bonus_count": 12,
+                "total_students_taught": 25,
+            }]
+        }
+    }
+
 
 class TeacherViewResponse(BaseModel):
     teacher: TeacherBasicInfo
@@ -92,3 +204,82 @@ class TeacherViewResponse(BaseModel):
     bonus_records_recent: list[TeacherBonusSummary] = []
     work_schedules: list[TeacherWorkScheduleSummary] = []
     stats: TeacherStats
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "teacher": {
+                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "teacher_no": "T001",
+                    "name": "陳老師",
+                    "email": "teacher@eop-education.com",
+                    "phone": "0923456789",
+                    "address": "台北市信義區松仁路50號",
+                    "bio": "10年英語教學經驗，專攻兒童英語與會話訓練",
+                    "avatar_url": "https://s3.amazonaws.com/eop/avatars/teacher001.jpg",
+                    "teacher_level": 3,
+                    "is_active": True,
+                    "email_verified_at": "2026-01-10T10:00:00",
+                    "created_at": "2026-01-05T09:00:00",
+                },
+                "account": {
+                    "has_account": True,
+                    "is_active": True,
+                    "role": "teacher",
+                },
+                "line_binding": {
+                    "bound": True,
+                    "line_display_name": "陳老師",
+                    "line_picture_url": "https://profile.line-scdn.net/def456",
+                    "binding_status": "active",
+                },
+                "contracts": [{
+                    "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                    "contract_no": "TC20260101001",
+                    "contract_status": "active",
+                    "start_date": "2026-01-01",
+                    "end_date": "2026-12-31",
+                    "employment_type": "part_time",
+                    "notes": "每週固定排課 12 小時",
+                    "addendum_count": 0,
+                }],
+                "bookings_recent": [{
+                    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                    "booking_date": "2026-04-15",
+                    "start_time": "14:00",
+                    "end_time": "15:00",
+                    "booking_status": "confirmed",
+                    "booking_type": "regular",
+                    "student_name": "王小明",
+                    "course_name": "英語初級會話",
+                }],
+                "bonus_records_recent": [{
+                    "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+                    "bonus_type": "trial_to_formal",
+                    "amount": 500.0,
+                    "bonus_date": "2026-04-10",
+                    "description": "學生王小明試上轉正獎金",
+                    "student_name": "王小明",
+                }],
+                "work_schedules": [{
+                    "id": "e5f6a7b8-c9d0-1234-efab-345678901234",
+                    "weekday": 1,
+                    "start_time": "09:00",
+                    "end_time": "12:00",
+                    "notes": "週一上午固定時段",
+                }],
+                "stats": {
+                    "total_bookings": 120,
+                    "completed_bookings": 95,
+                    "cancelled_bookings": 5,
+                    "pending_bookings": 3,
+                    "upcoming_bookings": 17,
+                    "total_contracts": 2,
+                    "active_contracts": 1,
+                    "total_bonus_amount": 15000.0,
+                    "total_bonus_count": 12,
+                    "total_students_taught": 25,
+                },
+            }]
+        }
+    }

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -11,6 +11,20 @@ class UserProfile(BaseModel):
     is_active: bool = True
     created_at: Optional[datetime] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "email": "teacher@eop-education.com",
+                "role": "teacher",
+                "name": "陳老師",
+                "avatar_url": "https://s3.amazonaws.com/eop/avatars/teacher001.jpg",
+                "is_active": True,
+                "created_at": "2026-01-15T09:00:00",
+            }]
+        }
+    }
+
 class UserSessionInfo(BaseModel):
     session_id: str
     user_agent: Optional[str] = None
@@ -37,6 +51,22 @@ class AccountInfo(BaseModel):
     is_active: bool = True
     is_protected: bool = False
     created_at: Optional[datetime] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "email": "employee@eop-education.com",
+                "name": "張主任",
+                "role": "employee",
+                "role_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "employee_subtype": "full_time",
+                "is_active": True,
+                "is_protected": False,
+                "created_at": "2026-01-10T08:00:00",
+            }]
+        }
+    }
 
 class AccountUpdate(BaseModel):
     """帳號更新"""

--- a/backend/app/schemas/zoom.py
+++ b/backend/app/schemas/zoom.py
@@ -71,8 +71,26 @@ class ZoomAccountResponse(BaseModel):
     created_by: Optional[str] = None
     updated_at: Optional[datetime] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "account_name": "EOP 教學帳號 A",
+                "zoom_account_id": "AbC1dEf2GhI3jKl4",
+                "zoom_client_id": "xYz5AbC6dEf7GhI8",
+                "zoom_user_email": "zoom-a@eop-education.com",
+                "account_tier": "pro",
+                "is_active": True,
+                "daily_meeting_count": 5,
+                "daily_count_reset_at": "2026-04-14",
+                "notes": "主要教學用帳號",
+                "created_at": "2026-01-15T09:00:00",
+                "created_by": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "updated_at": "2026-04-14T08:00:00",
+            }]
+        }
+    }
 
 
 class ZoomAccountListResponse(BaseModel):
@@ -121,8 +139,40 @@ class ZoomMeetingLogResponse(BaseModel):
     account_name: Optional[str] = None
     teacher_name: Optional[str] = None
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "booking_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "zoom_account_id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+                "teacher_id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+                "zoom_meeting_id": "98765432100",
+                "zoom_meeting_uuid": "AbCdEfGhIjKlMnOp==",
+                "join_url": "https://zoom.us/j/98765432100?pwd=abc123",
+                "start_url": "https://zoom.us/s/98765432100?zak=xyz789",
+                "passcode": "123456",
+                "meeting_date": "2026-04-15",
+                "start_time": "14:00:00",
+                "end_time": "15:00:00",
+                "meeting_status": "completed",
+                "recording_url": "https://zoom.us/rec/share/abc123",
+                "recording_download_url": "https://zoom.us/rec/download/abc123",
+                "recording_file_type": "MP4",
+                "recording_file_size_bytes": 524288000,
+                "recording_duration_seconds": 3600,
+                "recording_completed_at": "2026-04-15T15:05:00",
+                "recording_transfer_status": "completed",
+                "drive_file_id": "1AbCdEfGhIjKlMnOpQrStUvWxYz",
+                "drive_view_link": "https://drive.google.com/file/d/1AbCdEfGh/view",
+                "transferred_at": "2026-04-15T15:10:00",
+                "created_at": "2026-04-15T13:55:00",
+                "updated_at": "2026-04-15T15:10:00",
+                "account_name": "EOP 教學帳號 A",
+                "teacher_name": "陳老師",
+            }]
+        }
+    }
 
 
 class ZoomMeetingLogListResponse(BaseModel):
@@ -169,6 +219,20 @@ class DownloadTokenResponse(BaseModel):
     drive_folder_id: Optional[str] = None           # DB 設定的預設資料夾
     student_drive_folder_id: Optional[str] = None   # 學生專屬資料夾（正式學生）
     student_type: Optional[str] = None              # trial / formal（決定放哪個資料夾）
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "download_url": "https://zoom.us/rec/download/abc123def456",
+                "access_token": "eyJhbGciOiJIUzI1NiJ9.eyJ...",
+                "meeting_topic": "[BK20260415001] 英語初級會話 王小明 / 陳老師 2026-04-15 14:00",
+                "drive_mode": "sa",
+                "drive_folder_id": "1AbCdEfGhIjKlMnOpQrStUv",
+                "student_drive_folder_id": "1WxYzAbCdEfGhIjKlMnOpQ",
+                "student_type": "formal",
+            }]
+        }
+    }
 
 
 # ============================================

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -1,0 +1,115 @@
+# API 錯誤碼對照表
+
+所有 API 錯誤回傳格式：
+
+```json
+{
+  "success": false,
+  "message": "中文錯誤訊息（給使用者看）",
+  "detail": "中文錯誤訊息",
+  "error_code": "AUTH_ERROR"
+}
+```
+
+`error_code` 為英文 UPPER_SNAKE_CASE，供前端程式化處理。
+
+定義檔：`backend/app/core/error_codes.py`
+
+---
+
+## 401 — 認證失敗
+
+| error_code | 說明 | 觸發情境 |
+|------------|------|----------|
+| `AUTH_ERROR` | 通用認證錯誤 | 未提供 token、認證流程異常 |
+| `AUTH_TOKEN_EXPIRED` | Token 已過期 | JWT access token 超過有效期 |
+| `AUTH_TOKEN_INVALID` | 無效的 Token | Token 格式錯誤、簽名不符、已被列入黑名單 |
+| `AUTH_SESSION_EXPIRED` | Session 已過期 | Redis session 不存在或已銷毀 |
+| `AUTH_IDLE_TIMEOUT` | 閒置超時自動登出 | 使用者閒置超過設定時間（預設 10 分鐘） |
+| `AUTH_SESSION_REPLACED` | 帳號在其他裝置登入 | 同帳號不可重複登入，舊 session 被銷毀 |
+| `AUTH_LOGIN_FAILED` | 登入失敗 | 帳號或密碼錯誤 |
+| `AUTH_API_KEY_INVALID` | API Key 無效 | Service Account 的 API Key 驗證失敗 |
+
+## 403 — 權限不足
+
+| error_code | 說明 | 觸發情境 |
+|------------|------|----------|
+| `FORBIDDEN` | 通用權限不足 | 權限等級不夠 |
+| `FORBIDDEN_ROLE` | 角色限制 | 「僅限管理員操作」等角色檢查 |
+| `FORBIDDEN_OWNER` | 非資源擁有者 | 學生/教師嘗試操作他人資源 |
+| `FORBIDDEN_PROTECTED` | 受保護帳號 | 操作被標記為 is_protected 的帳號 |
+| `FORBIDDEN_PAGE` | 缺少頁面權限 | 角色未被授權存取該頁面功能 |
+
+## 404 — 資源不存在
+
+| error_code | 說明 | 觸發情境 |
+|------------|------|----------|
+| `NOT_FOUND` | 資源不存在 | ID 不存在或已被軟刪除 |
+
+## 400 — 請求錯誤
+
+| error_code | 說明 | 觸發情境 |
+|------------|------|----------|
+| `VALIDATION_ERROR` | 通用驗證錯誤 | 欄位格式不符、業務邏輯錯誤 |
+| `DUPLICATE_ENTRY` | 資料已存在 | Email 重複、編號重複等唯一性衝突 |
+| `NO_UPDATE_DATA` | 無更新內容 | PUT 請求未提供任何要更新的欄位 |
+| `INVALID_STATE` | 狀態不允許操作 | 如「只有待確認狀態的預約才可刪除」 |
+| `INVALID_FILE` | 檔案錯誤 | 檔案格式不支援、上傳失敗 |
+| `QUOTA_EXCEEDED` | 額度超限 | 如請假額度用完、合約堂數不足 |
+| `WRONG_PASSWORD` | 密碼錯誤 | 變更密碼時當前密碼不正確 |
+
+## 409 — 資源衝突
+
+| error_code | 說明 | 觸發情境 |
+|------------|------|----------|
+| `CONFLICT` | 資源衝突 | 預約時間重疊、並發操作衝突 |
+
+## 422 — 請求格式錯誤
+
+由 FastAPI/Pydantic 自動回傳，不走 error_code 系統。
+
+```json
+{
+  "detail": [{
+    "type": "value_error",
+    "loc": ["body", "email"],
+    "msg": "value is not a valid email address: An email address must have an @-sign.",
+    "input": "not-an-email"
+  }]
+}
+```
+
+常見觸發：EmailStr 格式驗證、必填欄位缺失、數值範圍不符。
+
+## 429 — 請求頻率過高
+
+| error_code | 說明 | 觸發情境 |
+|------------|------|----------|
+| `RATE_LIMITED` | 請求頻率過高 | Rate limiting middleware 攔截 |
+
+## 500 — 伺服器錯誤
+
+| error_code | 說明 | 觸發情境 |
+|------------|------|----------|
+| `INTERNAL_ERROR` | 伺服器內部錯誤 | 未預期的例外（detail 不暴露內部細節） |
+
+## 503 — 服務不可用
+
+| error_code | 說明 | 觸發情境 |
+|------------|------|----------|
+| `SERVICE_UNAVAILABLE` | 服務不可用 | 資料庫/Redis 連線失敗等 |
+
+---
+
+## 前端處理參考
+
+前端 `fetchWithAuth` 會解析 `error_code` 來決定行為：
+
+| error_code | 前端行為 |
+|------------|----------|
+| `AUTH_IDLE_TIMEOUT` | 導向 `/login?reason=idle` |
+| `AUTH_SESSION_REPLACED` | 導向 `/login?reason=replaced` |
+| `AUTH_SESSION_EXPIRED` / `AUTH_TOKEN_EXPIRED` | 嘗試 refresh，失敗則導向 `/login?reason=expired` |
+| 其他 401 | 嘗試 refresh，失敗則登出 |
+| 422 | 解析 `detail[0].msg` 顯示驗證錯誤 |
+| 其他 | 顯示 `message` 或 `detail` 給使用者 |


### PR DESCRIPTION
1. 補齊 ~45 個缺少 response_model 的端點
   - Options/下拉選單端點 → DataResponse
   - Overview 列表 → PaginatedResponse
   - Upload URL → UploadUrlResponse
   - Download URL → DownloadUrlResponse
   - 子資源 CRUD → DataResponse[T]
   - Alerts → AlertListResponse / UnreadCountResponse

2. 新增共用 response schemas
   - UploadUrlResponse, DownloadUrlResponse
   - AlertListResponse, UnreadCountResponse

3. 新增 docs/error-codes.md
   - 所有 HTTP 狀態碼 + error_code 對照表
   - 觸發情境說明 + 前端處理參考