### PR TITLE
feat(e2e): bootstrap accounts via super-admin invite flow

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -7,3 +7,4 @@ reports/
 *.log
 .env
 .env.local
+.env.e2e

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,16 +1,38 @@
-import { request, FullConfig } from '@playwright/test';
+import { request, APIRequestContext, FullConfig } from '@playwright/test';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import { ACCOUNTS, Role } from './tests/accounts';
 
 const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost';
+const META_FILE = path.resolve(__dirname, '.auth/run-meta.json');
+
+// ngrok free tunnel 對非瀏覽器流量會擋警告頁，加這個 header 直接跳過。
+// 對非 ngrok 環境是 no-op，所以不分環境一律帶。
+const REMOTE_HEADERS: Record<string, string> = {
+  'ngrok-skip-browser-warning': '1',
+};
+
+interface RunMeta {
+  runId: string;
+  baseUrl: string;
+  createdAt: string;
+  entities: {
+    employee?: { id: string; email: string };
+    teacher?: { id: string; email: string };
+    student?: { id: string; email: string };
+  };
+}
 
 /**
- * Backend 有 RateLimitMiddleware (300 req/min/IP)，密集 e2e 跑很容易撞牆。
+ * Backend 有 RateLimitMiddleware，密集 e2e 跑很容易撞牆。
  * 透過 docker exec 把 Redis 的 rate_limit:* keys 清乾淨，給測試一個乾淨起點。
+ * 線上環境跑 (E2E_BASE_URL 不是 localhost) 時跳過。
  */
 function flushRateLimitKeys(): void {
+  if (!BASE_URL.includes('localhost')) {
+    console.log('[global-setup] skip rate-limit flush on remote env:', BASE_URL);
+    return;
+  }
   const redisPassword = process.env.E2E_REDIS_PASSWORD || 'changeme';
   try {
     execSync(
@@ -23,35 +45,144 @@ function flushRateLimitKeys(): void {
   }
 }
 
-async function loginAndSaveState(role: Role) {
-  const account = ACCOUNTS[role];
-  const ctx = await request.newContext({ baseURL: BASE_URL });
-
-  const res = await ctx.post('/api/v1/auth/login', {
-    data: { email: account.email, password: account.password },
-  });
-
+async function loginContext(email: string, password: string): Promise<APIRequestContext> {
+  const ctx = await request.newContext({ baseURL: BASE_URL, extraHTTPHeaders: REMOTE_HEADERS });
+  const res = await ctx.post('/api/v1/auth/login', { data: { email, password } });
   if (!res.ok()) {
     const body = await res.text();
     await ctx.dispose();
-    throw new Error(
-      `[global-setup] login failed for ${role} (${account.email}): ${res.status()} ${body}`
-    );
+    throw new Error(`[global-setup] login failed (${email}): ${res.status()} ${body}`);
   }
+  return ctx;
+}
 
-  const filePath = path.resolve(__dirname, account.storageStateFile);
+async function saveStorage(ctx: APIRequestContext, storagePath: string): Promise<void> {
+  const filePath = path.resolve(__dirname, storagePath);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   await ctx.storageState({ path: filePath });
-  await ctx.dispose();
+}
 
-  console.log(`[global-setup] saved storage state: ${role} -> ${filePath}`);
+type NonAdminRole = 'employee' | 'teacher' | 'student';
+
+async function createEntity(
+  adminCtx: APIRequestContext,
+  role: NonAdminRole,
+  email: string,
+  runId: string
+): Promise<string> {
+  const endpoint =
+    role === 'employee' ? '/api/v1/employees' : role === 'teacher' ? '/api/v1/teachers' : '/api/v1/students';
+  const baseName = `E2E ${role} ${runId}`;
+
+  const payload: Record<string, unknown> =
+    role === 'employee'
+      ? {
+          employee_no: `E2E-${runId.slice(-12)}`,
+          employee_type: 'full_time',
+          name: baseName,
+          email,
+          hire_date: new Date().toISOString().slice(0, 10),
+        }
+      : role === 'teacher'
+      ? { name: baseName, email, teacher_level: 1 }
+      : { name: baseName, email, student_type: 'formal' };
+
+  const res = await adminCtx.post(endpoint, { data: payload });
+  if (!res.ok()) {
+    const body = await res.text();
+    throw new Error(`[global-setup] create ${role} failed: ${res.status()} ${body}`);
+  }
+  const json = await res.json();
+  const id = json?.data?.id ?? json?.id;
+  if (!id) throw new Error(`[global-setup] create ${role} returned no id: ${JSON.stringify(json)}`);
+  return id;
+}
+
+async function generateInviteToken(
+  adminCtx: APIRequestContext,
+  entityType: NonAdminRole,
+  entityId: string
+): Promise<string> {
+  const res = await adminCtx.post('/api/v1/invites/generate', {
+    data: { entity_type: entityType, entity_id: entityId },
+  });
+  if (!res.ok()) {
+    const body = await res.text();
+    throw new Error(`[global-setup] invite generate failed (${entityType}): ${res.status()} ${body}`);
+  }
+  const json = await res.json();
+  // /invites/generate 回傳 {invite_url, expires_at}（無 data wrapper）
+  const inviteUrl: string = json?.invite_url ?? json?.data?.invite_url;
+  if (!inviteUrl) throw new Error(`[global-setup] missing invite_url: ${JSON.stringify(json)}`);
+  const token = new URL(inviteUrl).searchParams.get('token');
+  if (!token) throw new Error(`[global-setup] missing token in invite_url: ${inviteUrl}`);
+  return token;
+}
+
+async function acceptInvite(token: string, password: string): Promise<void> {
+  const ctx = await request.newContext({ baseURL: BASE_URL, extraHTTPHeaders: REMOTE_HEADERS });
+  try {
+    const res = await ctx.post('/api/v1/invites/accept', { data: { token, password } });
+    if (!res.ok()) {
+      const body = await res.text();
+      throw new Error(`[global-setup] invite accept failed: ${res.status()} ${body}`);
+    }
+  } finally {
+    await ctx.dispose();
+  }
 }
 
 export default async function globalSetup(_config: FullConfig) {
+  // 1) 清掉前一次的 meta，避免 accounts.ts 讀到 stale runId
+  try {
+    if (fs.existsSync(META_FILE)) fs.unlinkSync(META_FILE);
+  } catch {
+    /* ignore */
+  }
+
   flushRateLimitKeys();
 
-  const roles: Role[] = ['admin', 'employee', 'teacher', 'student'];
-  for (const role of roles) {
-    await loginAndSaveState(role);
+  // 2) 用 require 動態載入 accounts，確保它在 meta 清掉之後才解析 runId
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { ACCOUNTS, RUN_ID } = require('./tests/accounts') as typeof import('./tests/accounts');
+
+  // 3) 先把 meta 寫上 runId（entities 之後再 patch），workers 一啟動就讀得到
+  const meta: RunMeta = {
+    runId: RUN_ID,
+    baseUrl: BASE_URL,
+    createdAt: new Date().toISOString(),
+    entities: {},
+  };
+  fs.mkdirSync(path.dirname(META_FILE), { recursive: true });
+  fs.writeFileSync(META_FILE, JSON.stringify(meta, null, 2), 'utf8');
+
+  // 4) super-admin login → save admin storageState
+  const admin = ACCOUNTS.admin;
+  const adminCtx = await loginContext(admin.email, admin.password);
+  await saveStorage(adminCtx, admin.storageStateFile);
+  console.log(`[global-setup] saved storage state: admin -> ${admin.storageStateFile}`);
+
+  // 5) bootstrap employee / teacher / student via invite flow
+  try {
+    for (const role of ['employee', 'teacher', 'student'] as const) {
+      const account = ACCOUNTS[role];
+      console.log(`[global-setup] bootstrap ${role} ${account.email}`);
+      const entityId = await createEntity(adminCtx, role, account.email, RUN_ID);
+      meta.entities[role] = { id: entityId, email: account.email };
+      // 每建一個就 flush 一次 meta，teardown 才能在中途失敗時還清掉已建好的部分
+      fs.writeFileSync(META_FILE, JSON.stringify(meta, null, 2), 'utf8');
+
+      const token = await generateInviteToken(adminCtx, role, entityId);
+      await acceptInvite(token, account.password);
+
+      const userCtx = await loginContext(account.email, account.password);
+      await saveStorage(userCtx, account.storageStateFile);
+      await userCtx.dispose();
+      console.log(`[global-setup] saved storage state: ${role} -> ${account.storageStateFile}`);
+    }
+  } finally {
+    await adminCtx.dispose();
   }
+
+  console.log(`[global-setup] runId=${RUN_ID} bootstrap complete`);
 }

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,98 @@
+import { request, FullConfig } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { ACCOUNTS } from './tests/accounts';
+
+const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost';
+const META_FILE = path.resolve(__dirname, '.auth/run-meta.json');
+
+interface RunMeta {
+  runId: string;
+  baseUrl: string;
+  createdAt: string;
+  entities: {
+    employee?: { id: string; email: string };
+    teacher?: { id: string; email: string };
+    student?: { id: string; email: string };
+  };
+}
+
+/**
+ * 清掉本次 run 在 invite flow 建立的 employee / teacher / student。
+ * 都是 soft delete（is_deleted=true），跑線上會留紀錄但帳號 email 已被使用，
+ * 同樣的 runId email 不會重複（runId 含 timestamp）。
+ *
+ * E2E_KEEP_ACCOUNTS=true → 跳過，方便除錯。
+ * 任何錯誤只 log 不 throw — 避免覆蓋掉真正的 test failure。
+ */
+export default async function globalTeardown(_config: FullConfig) {
+  if (process.env.E2E_KEEP_ACCOUNTS === 'true') {
+    console.log('[global-teardown] E2E_KEEP_ACCOUNTS=true, skip cleanup');
+    return;
+  }
+
+  if (!fs.existsSync(META_FILE)) {
+    console.log('[global-teardown] no run-meta.json found, skip cleanup');
+    return;
+  }
+
+  let meta: RunMeta;
+  try {
+    meta = JSON.parse(fs.readFileSync(META_FILE, 'utf8')) as RunMeta;
+  } catch (err) {
+    console.warn('[global-teardown] failed to parse run-meta.json:', err);
+    return;
+  }
+
+  const admin = ACCOUNTS.admin;
+  const ctx = await request.newContext({
+    baseURL: BASE_URL,
+    extraHTTPHeaders: { 'ngrok-skip-browser-warning': '1' },
+  });
+  try {
+    const loginRes = await ctx.post('/api/v1/auth/login', {
+      data: { email: admin.email, password: admin.password },
+    });
+    if (!loginRes.ok()) {
+      console.warn(
+        `[global-teardown] super-admin login failed (${loginRes.status()}), skip cleanup`
+      );
+      return;
+    }
+
+    const tasks: Array<{ role: string; endpoint: string }> = [];
+    if (meta.entities.employee) {
+      tasks.push({ role: 'employee', endpoint: `/api/v1/employees/${meta.entities.employee.id}` });
+    }
+    if (meta.entities.teacher) {
+      tasks.push({ role: 'teacher', endpoint: `/api/v1/teachers/${meta.entities.teacher.id}` });
+    }
+    if (meta.entities.student) {
+      tasks.push({ role: 'student', endpoint: `/api/v1/students/${meta.entities.student.id}` });
+    }
+
+    for (const t of tasks) {
+      try {
+        const res = await ctx.delete(t.endpoint);
+        if (res.ok()) {
+          console.log(`[global-teardown] deleted ${t.role}: ${t.endpoint}`);
+        } else {
+          const body = await res.text();
+          console.warn(`[global-teardown] delete ${t.role} failed: ${res.status()} ${body}`);
+        }
+      } catch (err) {
+        console.warn(`[global-teardown] delete ${t.role} error:`, err);
+      }
+    }
+  } finally {
+    await ctx.dispose();
+    // 清掉 meta，避免下次 setup 撞到 stale state
+    try {
+      fs.unlinkSync(META_FILE);
+    } catch {
+      /* noop */
+    }
+  }
+
+  console.log(`[global-teardown] runId=${meta.runId} cleanup done`);
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   ],
 
   globalSetup: require.resolve('./global-setup.ts'),
+  globalTeardown: require.resolve('./global-teardown.ts'),
 
   use: {
     baseURL: BASE_URL,
@@ -31,6 +32,8 @@ export default defineConfig({
     navigationTimeout: 15_000,
     extraHTTPHeaders: {
       Accept: 'application/json',
+      // ngrok free tunnel: 跳過 HTML 警告頁；對非 ngrok 是 no-op
+      'ngrok-skip-browser-warning': '1',
     },
   },
 

--- a/e2e/run-remote.sh
+++ b/e2e/run-remote.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# 跑 e2e 對遠端環境（staging / dev / ngrok tunnel 等）。
+#
+# Usage:
+#   ./run-remote.sh <BASE_URL> [playwright args...]
+#
+# 必填 env：
+#   E2E_ADMIN_EMAIL       super-admin email
+#   E2E_ADMIN_PASSWORD    super-admin password
+#
+# 選填 env：
+#   E2E_RUN_ID            固定 runId（debug 用，平常自動產生）
+#   E2E_KEEP_ACCOUNTS     true 跳過 teardown，方便看資料
+#   E2E_BOOTSTRAP_PASSWORD  e2e 動態建立 employee/teacher/student 帳號的密碼
+#                           (預設 E2eTestPwd123!)
+#   E2E_EMAIL_DOMAIN      e2e 帳號 email 網域 (預設 eop-test.com)
+#
+# 也可以把 env 寫進 ./.env.e2e（已被 .gitignore 排除），會自動載入。
+#
+# 範例：
+#   E2E_ADMIN_PASSWORD=xxx ./run-remote.sh https://staging.example.com
+#   E2E_ADMIN_PASSWORD=xxx ./run-remote.sh https://staging.example.com --project=admin --grep "頁面載入"
+#   E2E_ADMIN_PASSWORD=xxx E2E_KEEP_ACCOUNTS=true ./run-remote.sh https://staging.example.com
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//' >&2
+  exit 2
+}
+
+cd "$(dirname "$0")"
+
+# 載入 .env.e2e（如果存在）
+if [[ -f .env.e2e ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env.e2e
+  set +a
+fi
+
+BASE_URL="${1:-${E2E_BASE_URL:-}}"
+[[ "${BASE_URL}" =~ ^https?:// ]] || usage
+shift || true
+
+: "${E2E_ADMIN_EMAIL:?E2E_ADMIN_EMAIL not set (required)}"
+: "${E2E_ADMIN_PASSWORD:?E2E_ADMIN_PASSWORD not set (required)}"
+
+# 不在非 localhost 下偷跑 docker exec 清 redis（global-setup 內部已保護，這裡只是提示）
+if [[ "$BASE_URL" != *"localhost"* ]]; then
+  echo "[run-remote] target = $BASE_URL (remote)"
+  echo "[run-remote] note: rate-limit redis flush is skipped on remote"
+fi
+
+echo "[run-remote] admin = $E2E_ADMIN_EMAIL"
+echo "[run-remote] runId = ${E2E_RUN_ID:-<auto>}  keep_accounts=${E2E_KEEP_ACCOUNTS:-false}"
+
+# 不把密碼 echo 進 log
+E2E_BASE_URL="$BASE_URL" \
+E2E_ADMIN_EMAIL="$E2E_ADMIN_EMAIL" \
+E2E_ADMIN_PASSWORD="$E2E_ADMIN_PASSWORD" \
+E2E_RUN_ID="${E2E_RUN_ID:-}" \
+E2E_KEEP_ACCOUNTS="${E2E_KEEP_ACCOUNTS:-}" \
+E2E_BOOTSTRAP_PASSWORD="${E2E_BOOTSTRAP_PASSWORD:-}" \
+E2E_EMAIL_DOMAIN="${E2E_EMAIL_DOMAIN:-}" \
+npx playwright test "$@"

--- a/e2e/tests/accounts.ts
+++ b/e2e/tests/accounts.ts
@@ -1,3 +1,7 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
 export type Role = 'admin' | 'employee' | 'teacher' | 'student';
 
 export interface Account {
@@ -7,33 +11,72 @@ export interface Account {
   storageStateFile: string;
 }
 
-const adminPassword =
+const META_FILE = path.resolve(__dirname, '..', '.auth', 'run-meta.json');
+
+function generateRunId(): string {
+  const ts = new Date()
+    .toISOString()
+    .replace(/[-:T.Z]/g, '')
+    .slice(0, 14); // YYYYMMDDHHMMSS
+  const rand = crypto.randomBytes(2).toString('hex');
+  return `${ts}-${rand}`;
+}
+
+/**
+ * RUN_ID 取得順序：
+ *   1) E2E_RUN_ID env (允許從外部固定 runId)
+ *   2) .auth/run-meta.json 已存在的 runId (workers / teardown 走這條)
+ *   3) 自行產生新的 (global-setup 第一次跑)
+ *
+ * global-setup 會在開頭刪除 stale meta 檔，所以 setup 那次必走 (3)；
+ * 完成後寫入 meta，後續 workers 一律走 (2)，達到全跑共用同一個 runId。
+ */
+function resolveRunId(): string {
+  if (process.env.E2E_RUN_ID) return process.env.E2E_RUN_ID;
+  try {
+    if (fs.existsSync(META_FILE)) {
+      const meta = JSON.parse(fs.readFileSync(META_FILE, 'utf8'));
+      if (meta?.runId) return meta.runId;
+    }
+  } catch {
+    /* ignore */
+  }
+  return generateRunId();
+}
+
+export const RUN_ID: string = resolveRunId();
+
+const superEmail =
+  process.env.E2E_ADMIN_EMAIL || process.env.SUPER_ADMIN_EMAIL || 'eopAdmin@example.com';
+const superPassword =
   process.env.E2E_ADMIN_PASSWORD || process.env.SUPER_ADMIN_PASSWORD || 'eopsuper888';
-const defaultPassword = process.env.E2E_DEFAULT_PASSWORD || 'TestPassword123!';
+
+const bootstrapPassword = process.env.E2E_BOOTSTRAP_PASSWORD || 'E2eTestPwd123!';
+const emailDomain = process.env.E2E_EMAIL_DOMAIN || 'eop-test.com';
 
 export const ACCOUNTS: Record<Role, Account> = {
   admin: {
     role: 'admin',
-    email: process.env.E2E_ADMIN_EMAIL || 'eopAdmin@example.com',
-    password: adminPassword,
+    email: superEmail,
+    password: superPassword,
     storageStateFile: '.auth/admin.json',
   },
   employee: {
     role: 'employee',
-    email: process.env.E2E_EMPLOYEE_EMAIL || 'employee@eop-test.com',
-    password: defaultPassword,
+    email: `e2e-employee-${RUN_ID}@${emailDomain}`,
+    password: bootstrapPassword,
     storageStateFile: '.auth/employee.json',
   },
   teacher: {
     role: 'teacher',
-    email: process.env.E2E_TEACHER_EMAIL || 'teacher@eop-test.com',
-    password: defaultPassword,
+    email: `e2e-teacher-${RUN_ID}@${emailDomain}`,
+    password: bootstrapPassword,
     storageStateFile: '.auth/teacher.json',
   },
   student: {
     role: 'student',
-    email: process.env.E2E_STUDENT_EMAIL || 'student@eop-test.com',
-    password: defaultPassword,
+    email: `e2e-student-${RUN_ID}@${emailDomain}`,
+    password: bootstrapPassword,
     storageStateFile: '.auth/student.json',
   },
 };

--- a/e2e/tests/helpers/api.ts
+++ b/e2e/tests/helpers/api.ts
@@ -4,6 +4,12 @@ import { ACCOUNTS, Role } from '../accounts';
 
 const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost';
 
+// ngrok free tunnel 對非瀏覽器流量會擋一個 HTML 警告頁，加這個 header 直接跳過。
+// 對非 ngrok 環境是 no-op，所以不分環境一律帶。
+export const REMOTE_HEADERS: Record<string, string> = {
+  'ngrok-skip-browser-warning': '1',
+};
+
 /**
  * 取得已登入的 APIRequestContext。
  *
@@ -22,6 +28,7 @@ export async function getApiContext(role: Role): Promise<APIRequestContext> {
   return request.newContext({
     baseURL: BASE_URL,
     storageState: storageStatePath,
+    extraHTTPHeaders: REMOTE_HEADERS,
   });
 }
 

--- a/e2e/tests/helpers/seed.ts
+++ b/e2e/tests/helpers/seed.ts
@@ -44,7 +44,7 @@ export async function createEmployee(
   const suffix = uniqueSuffix();
   const employee_no = input.employee_no ?? `E2E-${suffix.toUpperCase().slice(0, 8)}`;
   const email = input.email ?? `e2e-emp-${suffix}@example.com`;
-  const name = input.name ?? `e2e Employee ${suffix.slice(0, 4)}`;
+  const name = input.name ?? `e2e Employee ${suffix}`;
 
   const res = await api.post('/api/v1/employees', {
     data: {
@@ -93,7 +93,7 @@ export async function createRole(
   const suffix = uniqueSuffix().replace(/-/g, '');
   // role key pattern: ^[a-z][a-z0-9_]*$
   const key = (input.key ?? `e2e_role_${suffix}`).toLowerCase().replace(/[^a-z0-9_]/g, '_');
-  const name = input.name ?? `e2e Role ${suffix.slice(0, 4)}`;
+  const name = input.name ?? `e2e Role ${suffix}`;
 
   const res = await api.post('/api/v1/roles', {
     data: { key, name, description: input.description ?? 'created by e2e' },
@@ -127,7 +127,7 @@ export async function createTeacher(
 ): Promise<SeededTeacher> {
   const suffix = uniqueSuffix();
   const email = input.email ?? `e2e-teacher-${suffix}@example.com`;
-  const name = input.name ?? `e2e Teacher ${suffix.slice(0, 4)}`;
+  const name = input.name ?? `e2e Teacher ${suffix}`;
 
   const res = await api.post('/api/v1/teachers', {
     data: {
@@ -164,7 +164,7 @@ export async function createStudent(
 ): Promise<SeededStudent> {
   const suffix = uniqueSuffix();
   const email = input.email ?? `e2e-student-${suffix}@example.com`;
-  const name = input.name ?? `e2e Student ${suffix.slice(0, 4)}`;
+  const name = input.name ?? `e2e Student ${suffix}`;
   const student_type = input.student_type ?? 'formal';
 
   const res = await api.post('/api/v1/students', {
@@ -196,7 +196,7 @@ export async function createCourse(
 ): Promise<SeededCourse> {
   const suffix = uniqueSuffix();
   const course_code = input.course_code ?? `E2E-${suffix.toUpperCase().slice(0, 8)}`;
-  const course_name = input.course_name ?? `e2e Course ${suffix.slice(0, 4)}`;
+  const course_name = input.course_name ?? `e2e Course ${suffix}`;
 
   const res = await api.post('/api/v1/courses', {
     data: {
@@ -278,7 +278,7 @@ export async function createZoomAccount(
   input: { account_name?: string } = {}
 ): Promise<SeededZoomAccount> {
   const suffix = uniqueSuffix();
-  const account_name = input.account_name ?? `e2e Zoom ${suffix.slice(0, 4)}`;
+  const account_name = input.account_name ?? `e2e Zoom ${suffix}`;
 
   const res = await api.post('/api/v1/zoom/accounts', {
     data: {


### PR DESCRIPTION
不再依賴 .env 預先 seed 的 employee@/teacher@/student@ 帳號；改由 super-admin 登入後依序對 employee / teacher / student 走真實 onboarding 流程：

  POST /<entity>s          → 建 entity（email 用 runId 動態組）
  POST /invites/generate   → 由 super-admin 取邀請 token
  POST /invites/accept     → 設密碼、建 user
  POST /auth/login         → 登入新帳號、存 storageState

跑完由 globalTeardown 走 super-admin 把建立的 entity soft-delete 掉。

主要動機：要能對任何環境（local docker / remote staging / ngrok tunnel）跑同 一套 e2e，不需要事先準備測試帳號。super-admin 帳號從 SUPER_ADMIN_EMAIL / SUPER_ADMIN_PASSWORD env 讀（也接受 E2E_ADMIN_* 覆寫）。

主要變更：
  - tests/accounts.ts: RUN_ID 改寫，從 .auth/run-meta.json 讀（跨 worker 共用）
  - global-setup.ts: 用 require() 動態載入 accounts，避免 import hoisting； 清舊 meta 檔，先寫 runId 再 bootstrap，確保 workers 看到一致 runId
  - global-teardown.ts (新): 走 super-admin soft-delete entities， E2E_KEEP_ACCOUNTS=true 可跳過清理
  - playwright.config.ts: 接上 globalTeardown，所有 request 帶 ngrok-skip-browser-warning header（對非 ngrok 是 no-op）
  - tests/helpers/api.ts: APIRequestContext 也帶 ngrok header
  - run-remote.sh (新): 一鍵跑遠端，吃 E2E_ADMIN_EMAIL/PASSWORD env， 可選 .env.e2e 檔
  - tests/helpers/seed.ts: e2e Teacher/Employee/... 名稱用完整 suffix， 避免短時間多次跑撞名（之前只取 4 字元，base36 timestamp 前綴幾乎相同）
  - .gitignore: 排除 .env.e2e

Verification:
  - local docker 142/142 全綠 (~36s)
  - remote ngrok 142/142 全綠 (1 flaky 重試後 OK，~57s, --workers=2)