### PR TITLE
hotfix(backend): 修 _coerce_value 把純數字 VARCHAR 值誤轉 int 的 500

### DIFF
--- a/backend/app/services/supabase_service.py
+++ b/backend/app/services/supabase_service.py
@@ -111,8 +111,13 @@ class SupabaseService:
         """Coerce string values to native Python types for asyncpg.
 
         asyncpg is strict about types — PostgreSQL boolean columns need
-        real bools, integer columns need ints, UUID columns need UUIDs,
-        date/time columns need native date/time objects, etc.
+        real bools, UUID columns need UUIDs, date/time columns need native
+        date/time objects.
+
+        注意：不在此處把純數字字串 coerce 成 int。整數欄位的 filter 值由呼叫端
+        直接傳 int（非 str），會在 _parse_filter 早期分支處理；若這裡硬把字串
+        "123" 當 int，會讓 VARCHAR 欄位（如 student_no、teacher_no、course_code）
+        在 user 填純數字時被 asyncpg reject 成「expected str, got int」。
         """
         low = val.lower()
         if low == "true":
@@ -121,11 +126,6 @@ class SupabaseService:
             return False
         if low == "null":
             return None
-        # Try integer
-        try:
-            return int(val)
-        except ValueError:
-            pass
         # Try UUID
         try:
             return uuid.UUID(val)


### PR DESCRIPTION
回報案例：
  POST /api/v1/students {"student_no":"123",...}
  → 500 "invalid input for query argument $1: 123 (expected str, got int)"

Root cause:
  supabase_service._parse_filter 對「無 prefix」的 string filter 值會呼叫
  _coerce_value 試型別轉換。_coerce_value 把任何純數字字串當 int 解析，
  導致 VARCHAR 欄位 (student_no, teacher_no, employee_no, course_code...)
  在 user 填純數字時，asyncpg 收到 int 卻要 bind text，當場 reject。

Fix:
  拿掉 _coerce_value 對純數字的 int 解析。整數欄位的 filter 通常呼叫端
  直接傳 int (走 _parse_filter 早期 not isinstance(str) 分支)，不依賴
  此處 coerce；其餘 UUID / bool / null / date / time 解析保留。

Verification:
  - 重現：POST /students {"student_no":"123",...} → 修前 500，修後 200 ✓
  - 一般字串 "ABC123" → 200 ✓
  - int 123 → 422 (Pydantic schema 擋下) ✓
  - 本地 e2e 142/142 全綠，無 regression