### PR TITLE
hotfix(backend): users 軟刪過濾 + bookings INTEGER filter + slot 排序 + student 必填 + teachers overview employment_type

### DIFF
--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -504,7 +504,9 @@ async def enrich_booking_with_relations(booking: dict) -> dict:
                     select="start_time,end_time",
                     filters={
                         "teacher_contract_id": f"eq.{booking['teacher_contract_id']}",
-                        "weekday": f"eq.{weekday}",
+                        # weekday 是 INTEGER 欄位，直接傳 int 走 _parse_filter 早期分支；
+                        # 不能用 f"eq.{weekday}"，因為 _coerce_value 不再 coerce 純數字字串為 int
+                        "weekday": weekday,
                         "is_deleted": "eq.false"
                     },
                 )

--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -2906,6 +2906,9 @@ async def get_teacher_slot_options(
         if date_to:
             slots = [s for s in slots if s.get("slot_date") <= date_to.isoformat()]
 
+        # 按日期 + 開始時間升冪排序（由近到遠）
+        slots.sort(key=lambda s: (s.get("slot_date") or "", s.get("start_time") or ""))
+
         return {"success": True, "message": "操作成功", "data": slots}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/api/v1/teachers.py
+++ b/backend/app/api/v1/teachers.py
@@ -123,10 +123,13 @@ async def list_teachers_overview(
     is_active: Optional[bool] = Query(None),
     has_account: Optional[bool] = Query(None),
     has_active_contract: Optional[bool] = Query(None),
+    employment_type: Optional[str] = Query(None, description="僅篩出最新 active 合約為此類型 (hourly/full_time)"),
     role: Optional[str] = Query(None, description="角色篩選 (student/teacher/admin/employee)"),
     current_user: CurrentUser = Depends(require_page_permission("teachers.list"))
 ):
     """教師總覽列表：每位教師一行，附帶合約/預約/帳號/獎金摘要"""
+    if employment_type is not None and employment_type not in ("hourly", "full_time"):
+        raise HTTPException(status_code=400, detail="employment_type 只能是 'hourly' 或 'full_time'")
     try:
         pool = supabase_service.pool
 
@@ -228,6 +231,10 @@ async def list_teachers_overview(
                 having_conditions.append("COALESCE(ct.active_contracts, 0) > 0")
             else:
                 having_conditions.append("COALESCE(ct.active_contracts, 0) = 0")
+        if employment_type is not None:
+            idx += 1
+            having_conditions.append(f"lac.employment_type = ${idx}")
+            params.append(employment_type)
 
         if having_conditions:
             base_sql += " AND " + " AND ".join(having_conditions)

--- a/backend/app/api/v1/teachers.py
+++ b/backend/app/api/v1/teachers.py
@@ -165,6 +165,7 @@ async def list_teachers_overview(
                 -- 合約摘要
                 COALESCE(ct.total_contracts, 0) AS total_contracts,
                 COALESCE(ct.active_contracts, 0) AS active_contracts,
+                lac.employment_type AS latest_active_employment_type,
                 -- 預約摘要
                 COALESCE(bk.total_bookings, 0) AS total_bookings,
                 COALESCE(bk.completed_bookings, 0) AS completed_bookings,
@@ -188,6 +189,15 @@ async def list_teachers_overview(
                 FROM teacher_contracts
                 WHERE teacher_id = t.id AND is_deleted = FALSE
             ) ct ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT employment_type
+                FROM teacher_contracts
+                WHERE teacher_id = t.id
+                  AND is_deleted = FALSE
+                  AND contract_status = 'active'
+                ORDER BY start_date DESC, created_at DESC
+                LIMIT 1
+            ) lac ON TRUE
             LEFT JOIN LATERAL (
                 SELECT
                     COUNT(*) AS total_bookings,
@@ -259,6 +269,7 @@ async def list_teachers_overview(
                 "line_display_name": row["line_display_name"],
                 "total_contracts": row["total_contracts"],
                 "active_contracts": row["active_contracts"],
+                "latest_active_employment_type": row["latest_active_employment_type"],
                 "total_bookings": row["total_bookings"],
                 "completed_bookings": row["completed_bookings"],
                 "upcoming_bookings": row["upcoming_bookings"],

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -83,7 +83,15 @@ async def list_users(
     try:
         # Build SQL with JOINs to get email and name
         params = []
-        where_clauses = []
+        where_clauses = [
+            # 過濾掉底下 entity 已軟刪除的帳號。
+            # user_profiles / public.users 本身沒有 is_deleted，
+            # 而 DELETE /<entity>s 只動 entity 的 is_deleted，不會聯動 user，
+            # 所以這層 LEFT JOIN 預設要把軟刪實體排除。
+            "COALESCE(e.is_deleted, false) = false",
+            "COALESCE(t.is_deleted, false) = false",
+            "COALESCE(s.is_deleted, false) = false",
+        ]
 
         base_sql = """
             SELECT

--- a/backend/app/schemas/student.py
+++ b/backend/app/schemas/student.py
@@ -7,9 +7,9 @@ class StudentCreate(BaseModel):
     """建立學生"""
     student_no: Optional[str] = Field(None, max_length=50, description="學生編號（留空自動產生 EOPS 格式）")
     name: str = Field(..., min_length=1, max_length=100, description="姓名")
-    eng_name: Optional[str] = Field(None, max_length=100, description="英文名")
+    eng_name: str = Field(..., min_length=1, max_length=100, description="英文名（必填）")
     email: EmailStr = Field(..., description="Email")
-    phone: Optional[str] = Field(None, max_length=20, description="電話")
+    phone: str = Field(..., min_length=1, max_length=20, description="電話（必填）")
     address: Optional[str] = Field(None, description="地址")
     birth_date: Optional[date] = Field(None, description="生日")
     id_number: Optional[str] = Field(None, max_length=20, description="身分證字號")

--- a/backend/tests/e2e/live_e2e_contracts_test.py
+++ b/backend/tests/e2e/live_e2e_contracts_test.py
@@ -179,7 +179,10 @@ class ContractsTester:
     async def _create_student(self):
         resp = await self._post("/api/v1/students", {
             "student_no": f"{TEST_PREFIX}S01", "name": f"{TEST_PREFIX}合約測試學生",
-            "email": f"{TEST_PREFIX}s@example.com", "student_type": "formal",
+            "eng_name": f"{TEST_PREFIX}eng",
+            "email": f"{TEST_PREFIX}s@example.com",
+            "phone": "0900000000",
+            "student_type": "formal",
         })
         if resp.status_code != 200: return f"{resp.status_code} {resp.text[:200]}"
         self.student_id = resp.json()["data"]["id"]

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -85,7 +85,13 @@ async function createEntity(
         }
       : role === 'teacher'
       ? { name: baseName, email, teacher_level: 1 }
-      : { name: baseName, email, student_type: 'formal' };
+      : {
+          name: baseName,
+          email,
+          eng_name: `e2e-eng-${runId}`,
+          phone: '0900000000',
+          student_type: 'formal',
+        };
 
   const res = await adminCtx.post(endpoint, { data: payload });
   if (!res.ok()) {

--- a/e2e/tests/group12-trial-to-formal/convert.spec.ts
+++ b/e2e/tests/group12-trial-to-formal/convert.spec.ts
@@ -123,6 +123,8 @@ test.describe('試上轉正 /students/{id}/convert-to-formal', () => {
       data: {
         name: 'e2e formal',
         email: `e2e-formal-${Date.now()}@example.com`,
+        eng_name: 'e2e-formal-eng',
+        phone: '0900000000',
         student_type: 'formal',
         is_active: true,
       },

--- a/e2e/tests/helpers/seed.ts
+++ b/e2e/tests/helpers/seed.ts
@@ -160,15 +160,17 @@ export interface SeededStudent {
 
 export async function createStudent(
   api: APIRequestContext,
-  input: { name?: string; email?: string; student_type?: 'formal' | 'trial' } = {}
+  input: { name?: string; email?: string; eng_name?: string; phone?: string; student_type?: 'formal' | 'trial' } = {}
 ): Promise<SeededStudent> {
   const suffix = uniqueSuffix();
   const email = input.email ?? `e2e-student-${suffix}@example.com`;
   const name = input.name ?? `e2e Student ${suffix}`;
+  const eng_name = input.eng_name ?? `e2e-eng-${suffix}`;
+  const phone = input.phone ?? '0900000000';
   const student_type = input.student_type ?? 'formal';
 
   const res = await api.post('/api/v1/students', {
-    data: { name, email, student_type, is_active: true },
+    data: { name, email, eng_name, phone, student_type, is_active: true },
   });
   if (!res.ok()) throw new Error(`createStudent failed: ${res.status()} ${await res.text()}`);
   const body = await res.json();


### PR DESCRIPTION
## Summary

六個 backend 改動，packed 在同一個 PR。

### 1. `GET /api/v1/users` 排除底下 entity 已軟刪除的帳號（commit `ab9861e`）

- 之前會列出底下 employee/teacher/student 已 `is_deleted=true` 的帳號（本機 DB 15 筆中 11 筆是軟刪實體）。
- **Root cause**：`user_profiles` / `public.users` 沒 `is_deleted` 欄位，`DELETE /<entity>s` 不聯動 user。`/users` SQL LEFT JOIN 沒過濾。
- **Fix**：在 `where_clauses` 預設加 3 條 `COALESCE(<entity>.is_deleted, false) = false`。

### 2. `enrich_booking_with_relations` 對 INTEGER `weekday` 用 f-string filter 造成 500（commit `2faed01`）

- 對 `employment_type=full_time` 教師合約預約後 enrichment 失敗 → 500，但 booking 已 commit（user 觀察「實際上會預約成功」）。
- **Root cause**：PR #27 拿掉 `_coerce_value` 的純數字→int 解析（修 student_no 撞 VARCHAR）。`bookings.py:507` 仍用 `f"eq.{weekday}"` 過濾 INTEGER 欄位 `teacher_work_schedules.weekday`，依賴 _coerce_value 還原 int。改動後該路徑回傳 str → asyncpg 對 INTEGER 欄位收 str 直接 reject。
- **Fix**：直接傳 int `weekday`，走 `_parse_filter` 早期 `not isinstance(value, str)` 分支。全 codebase 掃過，這是**唯一一處** INT 欄位用 `f"eq.{int_var}"` 的 callsite。

### 3. `GET /options/teacher-slots/{teacher_id}` 結果按時間升冪排序（commit `dd7f4a4`）

- 之前未排序，回傳順序依 DB 預設不穩定。
- **Fix**：endpoint 回傳前 `slots.sort(key=lambda s: (s["slot_date"], s["start_time"]))`，由近到遠（升冪）。

### 4. `POST /api/v1/students` 把 `eng_name` + `phone` 改為必填（commit `0070621`）

- `StudentCreate.eng_name` / `phone` 從 Optional → required (`min_length=1`)。
- 連帶更新 e2e 工具：`seed.ts createStudent`、`global-setup.ts` bootstrap、`group12 convert.spec.ts` 內聯 POST 補上預設 `eng_name` / `phone`。

### 5. `GET /api/v1/teachers/overview/list` 新增 `latest_active_employment_type` 欄位（commit `ea21a9e`）

- 教師總覽列表現在會回傳「該教師最新一筆 active 合約的 employment_type」（`'hourly' | 'full_time' | null`）。
- **實作**：LEFT JOIN LATERAL 子查詢，`ORDER BY start_date DESC, created_at DESC LIMIT 1`，僅篩 `is_deleted=false AND contract_status='active'`。
- 順手修 `live_e2e_contracts_test.py _create_student` 漏補 `eng_name`/`phone`（commit #4 漏改的 Python e2e）→ 該檔從 16/35 修回 35/35 全綠。

### 6. `GET /api/v1/teachers/overview/list` 新增 `employment_type` query 篩選（commit `4afed92`）

- `?employment_type=full_time` → 只回傳最新 active 合約為 `full_time` 的教師。
- `?employment_type=hourly` → 同上但 hourly。
- 未提供 → 不篩選。
- 白名單驗證：非 `hourly`/`full_time` → 400 Bad Request。
- SQL 安全：用 `$N` placeholder 綁定，禁止 f-string 拼值。

## Test plan

- [x] 本機 `GET /api/v1/users` 從 15 → 4 筆（11 個軟刪實體被排除）
- [x] 本機 `GET /api/v1/bookings/{id}`（full_time 合約預約）→ 200（之前 500）
- [x] `student_no="123"` 路徑（PR #27 修法）不受影響
- [x] 本機 `GET /options/teacher-slots/{tid}` 排序檢查 PASS（`slot_date` + `start_time` 升冪）
- [x] 本機 POST /students 4 case 驗證：缺兩欄 / 缺 eng_name / eng_name 空字串 / 全齊全 → 422 / 422 / 422 / 200
- [x] 本機 `GET /api/v1/teachers/overview/list`：T002 (full_time active) → `full_time`；其他 active 教師 → `hourly`；無 active 合約 → `null`
- [x] 本機 `GET /api/v1/teachers/overview/list?employment_type=full_time` → 1（T002）
- [x] 本機 `GET /api/v1/teachers/overview/list?employment_type=hourly` → 7
- [x] 本機 `GET /api/v1/teachers/overview/list?employment_type=bad` → 400
- [x] 加總 1+7+5（無 active）= 13 = 不帶篩選的 total ✓
- [x] 本機 e2e 142/142 全綠（無 regression）
- [x] `live_e2e_teacher_flow_test.py` 21/21 PASS
- [x] `live_e2e_contracts_test.py` 35/35 PASS（修補後）
- [x] 部署到 staging 驗證

## Notes

- 六個 commit 屬於不同 issue，但都在迭代週期裡發現，合在一個 PR 比較好追歷史。
- E2E 沒抓到 #2 是因為現有 booking 測試用的 teacher_contract 不是 `full_time`，不會走進 enrichment 的 weekday 分支。後續可考慮補一個 full_time 路徑的 booking 測試。
- #4 改動會影響「外部直接呼叫 `/students` 而不帶 `eng_name`/`phone`」的 client，部署前需確認前端 form 已連動。
- #5/#6 是純加欄位/查詢參數、不影響既有行為，前端可漸進式採用。