### PR TITLE
hotfix(teacher-slots): 強制 contract_id 必填 + active 驗證 + 修 trial+正職 booking 500

### DIFF
--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -7,7 +7,7 @@ from app.schemas.booking import (
     BookingBatchUpdateByIds, BookingBatchDeleteByIds, BookingBatchUpdate, BookingBatchDelete,
     BookingBatchCreate, TimeBlock, SlotAvailabilityResponse
 )
-from app.schemas.response import BaseResponse, DataResponse, StudentOption, TeacherOption, CourseOption, ContractOption, SlotOption
+from app.schemas.response import BaseResponse, DataResponse, StudentOption, TeacherOption, CourseOption, ContractOption, TeacherContractOption, SlotOption
 from typing import Optional, List
 from datetime import date, datetime, time
 import asyncio
@@ -1282,6 +1282,14 @@ async def create_booking(
             # 使用時段的教師合約（如果沒有指定）
             if not teacher_contract_id and matching_slot.get("teacher_contract_id"):
                 teacher_contract_id = matching_slot["teacher_contract_id"]
+
+        # bookings.teacher_contract_id 是 NOT NULL；舊資料殘留可能有 slot
+        # 沒綁合約，遇到時直接擋並提示重建時段。
+        if not teacher_contract_id:
+            raise HTTPException(
+                status_code=400,
+                detail="此時段無有效教師有效合約，請重新建立時段",
+            )
 
         # 取得操作者的 employee_id
         employee_id = await get_user_employee_id(current_user.user_id)
@@ -2857,7 +2865,7 @@ async def get_substitute_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/options/teacher-contracts/{teacher_id}", tags=["預約管理"], response_model=DataResponse[List[ContractOption]])
+@router.get("/options/teacher-contracts/{teacher_id}", tags=["預約管理"], response_model=DataResponse[List[TeacherContractOption]])
 async def get_teacher_contract_options(
     teacher_id: str,
     current_user: CurrentUser = Depends(require_page_permission("bookings.list"))

--- a/backend/app/api/v1/teacher_slots.py
+++ b/backend/app/api/v1/teacher_slots.py
@@ -6,7 +6,7 @@ from app.schemas.teacher_slot import (
     TeacherSlotBatchDeleteByIds, TeacherSlotBatchUpdateByIds,
     TeacherSlotUpdate, TeacherSlotResponse, TeacherSlotListResponse
 )
-from app.schemas.response import BaseResponse, DataResponse, TeacherOption, ContractOption
+from app.schemas.response import BaseResponse, DataResponse, TeacherOption, TeacherContractOption
 from typing import Optional, List
 from datetime import date, datetime, timedelta
 import math
@@ -176,7 +176,7 @@ async def get_teacher_options(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/my-contracts", tags=["教師時段管理"], response_model=DataResponse[List[ContractOption]])
+@router.get("/my-contracts", tags=["教師時段管理"], response_model=DataResponse[List[TeacherContractOption]])
 async def get_my_contracts(
     current_user: CurrentUser = Depends(require_page_permission("teachers.slots"))
 ):
@@ -260,15 +260,22 @@ async def create_teacher_slot(
         if not teacher:
             raise HTTPException(status_code=400, detail="教師不存在")
 
-        # 驗證教師合約存在（如果有提供）
-        if data.teacher_contract_id:
-            contract = await supabase_service.table_select(
-                table="teacher_contracts",
-                select="id",
-                filters={"id": data.teacher_contract_id, "is_deleted": "eq.false"},
+        # 驗證教師合約：必須屬於該老師、active、未刪除
+        contract = await supabase_service.table_select(
+            table="teacher_contracts",
+            select="id",
+            filters={
+                "id": data.teacher_contract_id,
+                "teacher_id": data.teacher_id,
+                "contract_status": "eq.active",
+                "is_deleted": "eq.false",
+            },
+        )
+        if not contract:
+            raise HTTPException(
+                status_code=400,
+                detail="教師無有效合約，無法建立時段",
             )
-            if not contract:
-                raise HTTPException(status_code=400, detail="教師合約不存在")
 
         # 取得操作者的 employee_id
         employee_id = await get_user_employee_id(current_user.user_id)
@@ -332,15 +339,22 @@ async def create_teacher_slots_batch(
         if not teacher:
             raise HTTPException(status_code=400, detail="教師不存在")
 
-        # 驗證教師合約存在（如果有提供）
-        if data.teacher_contract_id:
-            contract = await supabase_service.table_select(
-                table="teacher_contracts",
-                select="id",
-                filters={"id": data.teacher_contract_id, "is_deleted": "eq.false"},
+        # 驗證教師合約：必須屬於該老師、active、未刪除
+        contract = await supabase_service.table_select(
+            table="teacher_contracts",
+            select="id",
+            filters={
+                "id": data.teacher_contract_id,
+                "teacher_id": data.teacher_id,
+                "contract_status": "eq.active",
+                "is_deleted": "eq.false",
+            },
+        )
+        if not contract:
+            raise HTTPException(
+                status_code=400,
+                detail="教師沒有 active 合約，無法建立時段",
             )
-            if not contract:
-                raise HTTPException(status_code=400, detail="教師合約不存在")
 
         # 取得操作者的 employee_id
         employee_id = await get_user_employee_id(current_user.user_id)
@@ -780,6 +794,24 @@ async def update_teacher_slot(
         if data.slot_date is not None or data.start_time is not None or data.end_time is not None:
             if await slot_has_active_bookings(slot_id):
                 raise HTTPException(status_code=400, detail="有預約的時段無法修改日期或時間")
+
+        # 若更新含 teacher_contract_id：必須屬於該老師、active、未刪除
+        if data.teacher_contract_id is not None:
+            contract = await supabase_service.table_select(
+                table="teacher_contracts",
+                select="id",
+                filters={
+                    "id": data.teacher_contract_id,
+                    "teacher_id": slot["teacher_id"],
+                    "contract_status": "eq.active",
+                    "is_deleted": "eq.false",
+                },
+            )
+            if not contract:
+                raise HTTPException(
+                    status_code=400,
+                    detail="教師沒有有效合約，無法更新時段合約",
+                )
 
         # 更新時段
         update_data = {k: v for k, v in data.model_dump().items() if v is not None}

--- a/backend/app/schemas/response.py
+++ b/backend/app/schemas/response.py
@@ -143,7 +143,7 @@ class CourseOption(BaseModel):
     }
 
 class ContractOption(BaseModel):
-    """合約下拉選項"""
+    """學生合約下拉選項"""
     id: str
     contract_no: str
     remaining_lessons: Optional[int] = None
@@ -162,6 +162,21 @@ class ContractOption(BaseModel):
                 "course_ids": ["b2c3d4e5-f6a7-8901-bcde-f12345678901"],
                 "course_name": "英語初級會話",
                 "created_at": "2026-03-15T10:00:00",
+            }]
+        }
+    }
+
+
+class TeacherContractOption(BaseModel):
+    """教師合約下拉選項"""
+    id: str
+    contract_no: str
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "contract_no": "TC20260101001",
             }]
         }
     }

--- a/backend/app/schemas/teacher_slot.py
+++ b/backend/app/schemas/teacher_slot.py
@@ -17,7 +17,7 @@ def _add_months(d: date, months: int) -> date:
 
 class TeacherSlotBase(BaseModel):
     teacher_id: str = Field(..., description="教師 ID")
-    teacher_contract_id: Optional[str] = Field(None, description="教師合約 ID")
+    teacher_contract_id: str = Field(..., description="教師合約 ID（必填，必須為該老師當下 active 合約）")
     slot_date: date = Field(..., description="時段日期")
     start_time: time = Field(..., description="開始時間")
     end_time: time = Field(..., description="結束時間")
@@ -52,7 +52,7 @@ class TeacherSlotCreate(TeacherSlotBase):
 class TeacherSlotBatchCreate(BaseModel):
     """批次建立教師時段的請求（週期性），日期範圍不得超過三個月"""
     teacher_id: str = Field(..., description="教師 ID")
-    teacher_contract_id: Optional[str] = Field(None, description="教師合約 ID")
+    teacher_contract_id: str = Field(..., description="教師合約 ID（必填，必須為該老師當下 active 合約）")
     start_date: date = Field(..., description="開始日期")
     end_date: date = Field(..., description="結束日期")
     weekdays: List[int] = Field(..., description="星期幾（0=週一, 6=週日）")

--- a/backend/tests/e2e/live_e2e_booking_flow_test.py
+++ b/backend/tests/e2e/live_e2e_booking_flow_test.py
@@ -305,7 +305,9 @@ class E2EBookingFlowTester:
         resp = await self._post("/api/v1/students", {
             "student_no": f"{TEST_PREFIX}S001",
             "name": f"{TEST_PREFIX}測試學生",
+            "eng_name": f"{TEST_PREFIX}eng",
             "email": f"e2e_student_{datetime.now().strftime('%H%M%S')}@example.com",
+            "phone": "0900000000",
             "student_type": "formal",
         })
         if resp.status_code != 200:
@@ -644,7 +646,9 @@ class E2EBookingFlowTester:
         """不提供 student_no，驗證自動產生 EOPS 格式"""
         resp = await self._post("/api/v1/students", {
             "name": f"{TEST_PREFIX}自動編號學生",
+            "eng_name": f"{TEST_PREFIX}eng_auto",
             "email": f"e2e_auto_s_{datetime.now().strftime('%H%M%S%f')}@example.com",
+            "phone": "0900000001",
         })
         if resp.status_code != 200:
             return f"Create auto student failed: {resp.status_code} {resp.text[:200]}"

--- a/backend/tests/e2e/live_e2e_courses_test.py
+++ b/backend/tests/e2e/live_e2e_courses_test.py
@@ -177,7 +177,10 @@ class CoursesEnrollmentTester:
     async def _create_student(self):
         resp = await self._post("/api/v1/students", {
             "student_no": f"{TEST_PREFIX}S01", "name": f"{TEST_PREFIX}選課測試學生",
-            "email": f"{TEST_PREFIX}s@example.com", "student_type": "formal",
+            "eng_name": f"{TEST_PREFIX}eng",
+            "email": f"{TEST_PREFIX}s@example.com",
+            "phone": "0900000000",
+            "student_type": "formal",
         })
         if resp.status_code != 200: return f"{resp.status_code} {resp.text[:200]}"
         self.student_id = resp.json()["data"]["id"]

--- a/backend/tests/e2e/live_e2e_overtime_test.py
+++ b/backend/tests/e2e/live_e2e_overtime_test.py
@@ -222,7 +222,9 @@ class E2EOvertimePayTester:
         resp = await self._post("/api/v1/students", {
             "student_no": f"{TEST_PREFIX}S001",
             "name": f"{TEST_PREFIX}加班費測試學生",
+            "eng_name": f"{TEST_PREFIX}eng",
             "email": f"ot_student_{_TS}@example.com",
+            "phone": "0900000000",
             "student_type": "formal",
         })
         if resp.status_code != 200:

--- a/backend/tests/e2e/live_e2e_student_flow_test.py
+++ b/backend/tests/e2e/live_e2e_student_flow_test.py
@@ -144,7 +144,9 @@ class StudentFlowTester:
         resp = await self._post("/api/v1/students", {
             "student_no": f"{TEST_PREFIX}S01", "name": f"{TEST_PREFIX}王小明",
             "eng_name": "Wang Xiaoming",
-            "email": f"{TEST_PREFIX}s@example.com", "student_type": "formal",
+            "email": f"{TEST_PREFIX}s@example.com",
+            "phone": "0900000000",
+            "student_type": "formal",
         })
         if resp.status_code != 200: return f"{resp.status_code} {resp.text[:200]}"
         self.student_id = resp.json()["data"]["id"]

--- a/backend/tests/e2e/live_e2e_teacher_flow_test.py
+++ b/backend/tests/e2e/live_e2e_teacher_flow_test.py
@@ -117,10 +117,14 @@ class TeacherFlowTester:
             print("\n  Phase 3: 可用時段")
             print("  " + "-" * 40)
 
+            await self._test("建立時段：缺 teacher_contract_id → 422", self._create_slot_missing_contract)
+            await self._test("建立時段：合約不屬於該老師 → 400", self._create_slot_cross_teacher_contract)
+            await self._test("建立時段：合約非 active → 400", self._create_slot_inactive_contract)
             await self._test("建立教師時段 (09:00-12:00)", self._create_slot)
             await self._test("查詢時段列表", self._list_slots)
             await self._test("編輯時段（改為不可用）", self._update_slot_unavailable)
             await self._test("編輯時段（恢復可用）", self._update_slot_available)
+            await self._test("更新時段：合約非 active → 400", self._update_slot_inactive_contract)
 
             print("\n  Phase 4: 總覽 API 驗證")
             print("  " + "-" * 40)
@@ -226,6 +230,77 @@ class TeacherFlowTester:
         })
         if resp.status_code != 200: return f"{resp.status_code} {resp.text[:200]}"
         self.teacher_slot_id = resp.json()["data"]["id"]
+        return True
+
+    async def _create_slot_missing_contract(self):
+        """schema 必填：teacher_contract_id 缺漏 → 422"""
+        resp = await self._post("/api/v1/teacher-slots", {
+            "teacher_id": self.teacher_id,
+            "slot_date": self.slot_date, "start_time": "13:00", "end_time": "14:00",
+            "is_available": True,
+        })
+        if resp.status_code != 422: return f"expected 422, got {resp.status_code} {resp.text[:200]}"
+        return True
+
+    async def _create_slot_cross_teacher_contract(self):
+        """合約屬於別的老師 → 400"""
+        # 建第二個 teacher + active 合約
+        resp = await self._post("/api/v1/teachers", {
+            "teacher_no": f"{TEST_PREFIX}T02", "name": f"{TEST_PREFIX}陳老師",
+            "email": f"{TEST_PREFIX}t2@example.com", "teacher_level": 1,
+        })
+        if resp.status_code != 200: return f"create teacher2: {resp.status_code} {resp.text[:200]}"
+        other_teacher_id = resp.json()["data"]["id"]
+        self._other_teacher_id = other_teacher_id  # for cleanup
+
+        start = date.today().isoformat()
+        end = (date.today() + timedelta(days=365)).isoformat()
+        resp = await self._post("/api/v1/teacher-contracts", {
+            "teacher_id": other_teacher_id, "contract_status": "active",
+            "start_date": start, "end_date": end, "employment_type": "hourly",
+        })
+        if resp.status_code != 200: return f"create contract2: {resp.status_code} {resp.text[:200]}"
+        other_contract_id = resp.json()["data"]["id"]
+        self._other_contract_id = other_contract_id
+
+        # 用 teacher1 + 別人的合約 → 應該 400
+        resp = await self._post("/api/v1/teacher-slots", {
+            "teacher_id": self.teacher_id,
+            "teacher_contract_id": other_contract_id,
+            "slot_date": self.slot_date, "start_time": "13:00", "end_time": "14:00",
+            "is_available": True,
+        })
+        if resp.status_code != 400: return f"expected 400, got {resp.status_code} {resp.text[:200]}"
+        return True
+
+    async def _create_slot_inactive_contract(self):
+        """合約 status != active → 400"""
+        # 建一個 pending 合約
+        start = date.today().isoformat()
+        end = (date.today() + timedelta(days=365)).isoformat()
+        resp = await self._post("/api/v1/teacher-contracts", {
+            "teacher_id": self.teacher_id, "contract_status": "pending",
+            "start_date": start, "end_date": end, "employment_type": "hourly",
+        })
+        if resp.status_code != 200: return f"create pending contract: {resp.status_code} {resp.text[:200]}"
+        pending_contract_id = resp.json()["data"]["id"]
+        self._pending_contract_id = pending_contract_id
+
+        resp = await self._post("/api/v1/teacher-slots", {
+            "teacher_id": self.teacher_id,
+            "teacher_contract_id": pending_contract_id,
+            "slot_date": self.slot_date, "start_time": "13:00", "end_time": "14:00",
+            "is_available": True,
+        })
+        if resp.status_code != 400: return f"expected 400, got {resp.status_code} {resp.text[:200]}"
+        return True
+
+    async def _update_slot_inactive_contract(self):
+        """更新 slot 時若帶非 active 合約 → 400"""
+        resp = await self._put(f"/api/v1/teacher-slots/{self.teacher_slot_id}", {
+            "teacher_contract_id": self._pending_contract_id,
+        })
+        if resp.status_code != 400: return f"expected 400, got {resp.status_code} {resp.text[:200]}"
         return True
 
     async def _list_slots(self):
@@ -341,11 +416,19 @@ class TeacherFlowTester:
         return f"expected 404, got {resp.status_code}"
 
     async def _cleanup(self):
+        # 額外建立的 teacher2 / 合約（cross-teacher / pending 測試用）
+        other_teacher_id = getattr(self, "_other_teacher_id", None)
+        other_contract_id = getattr(self, "_other_contract_id", None)
+        pending_contract_id = getattr(self, "_pending_contract_id", None)
+
         for name, path in [
             ("slot", f"/api/v1/teacher-slots/{self.teacher_slot_id}" if self.teacher_slot_id else None),
             ("detail", f"/api/v1/teacher-contracts/{self.teacher_contract_id}/details/{self.teacher_contract_detail_id}" if self.teacher_contract_id and self.teacher_contract_detail_id else None),
             ("contract", f"/api/v1/teacher-contracts/{self.teacher_contract_id}" if self.teacher_contract_id else None),
+            ("pending_contract", f"/api/v1/teacher-contracts/{pending_contract_id}" if pending_contract_id else None),
+            ("other_contract", f"/api/v1/teacher-contracts/{other_contract_id}" if other_contract_id else None),
             ("teacher", f"/api/v1/teachers/{self.teacher_id}" if self.teacher_id else None),
+            ("other_teacher", f"/api/v1/teachers/{other_teacher_id}" if other_teacher_id else None),
             ("course", f"/api/v1/courses/{self.course_id}" if self.course_id else None),
         ]:
             if not path: continue

--- a/supabase/migrations/055_backfill_teacher_slot_contract.sql
+++ b/supabase/migrations/055_backfill_teacher_slot_contract.sql
@@ -1,0 +1,20 @@
+-- 055: Backfill teacher_available_slots.teacher_contract_id
+-- 將 teacher_contract_id IS NULL 的時段補上該老師最新一筆 active 合約 id
+-- 該老師當下沒 active 合約 → 維持 NULL（後端 POST /bookings 會擋並提示重建時段）
+-- 規則：teacher_contracts 中 is_deleted=false 且 contract_status='active'，
+--       依 start_date DESC, created_at DESC 取一筆。
+
+UPDATE teacher_available_slots s
+SET teacher_contract_id = lac.id
+FROM (
+    SELECT DISTINCT ON (tc.teacher_id)
+        tc.teacher_id,
+        tc.id
+    FROM teacher_contracts tc
+    WHERE tc.is_deleted = FALSE
+      AND tc.contract_status = 'active'
+    ORDER BY tc.teacher_id, tc.start_date DESC, tc.created_at DESC
+) lac
+WHERE s.teacher_id = lac.teacher_id
+  AND s.teacher_contract_id IS NULL
+  AND s.is_deleted = FALSE;


### PR DESCRIPTION
## Summary

修兩個相關問題、清一個 schema、補 E2E。

### 1. 修復：試上學生 + 正職教師預約 500（root cause）

**問題**：
- `bookings.teacher_contract_id` 是 NOT NULL（schema 一開始就是）
- `teacher_available_slots.teacher_contract_id` 是 nullable
- 當 client 沒帶 `teacher_contract_id` 且選到的 slot 也沒綁合約 → INSERT 違反 NOT NULL → 500
- 觸發路徑：試上學生（無 student_contract）+ 正職教師（slot 建立時沒填 contract_id）

**修法**：從源頭擋 + booking 端 guard

#### 1a. Slot 建立 / 更新必須驗證合約

`schemas/teacher_slot.py`：
- `TeacherSlotBase.teacher_contract_id` & `TeacherSlotBatchCreate.teacher_contract_id`：`Optional[str]` → `str = Field(..., ...)`

`api/v1/teacher_slots.py`：
- `POST /teacher-slots`、`POST /teacher-slots/batch`：合約必須 `id + teacher_id 配對 + contract_status='active' + is_deleted=false`，任一不符 → 400 「教師沒有 active 合約，無法建立時段」
- `PUT /teacher-slots/{slot_id}`：若請求帶 `teacher_contract_id`，套相同檢查（`teacher_id` 來自既有 slot，防跨老師偷塞）

#### 1b. Booking 端 fallback 改成清楚錯誤

`api/v1/bookings.py`：
- slot 解析完仍為 None → 400 「此時段無有效教師有效合約，請重新建立時段」
- 不撞 DB NOT NULL 也不拋 500，使用者清楚知道要重建時段（為舊資料殘留路徑兜底）

### 2. Schema 清理：拆 `TeacherContractOption`

原本 `ContractOption` 是 student / teacher 共用，teacher 端只用到 `id` + `contract_no`，response 永遠回 4 個 null 欄位（`remaining_lessons`、`course_id`、`course_ids`、`course_name`、`created_at`）。

`schemas/response.py`：
- 新增 `TeacherContractOption(id, contract_no)`
- `ContractOption` docstring 更新為「學生合約下拉選項」

對應端點改用：
- `teacher_slots.py:179` `/teacher-slots/my-contracts` (teacher)
- `bookings.py:2868` `/bookings/options/teacher-contracts/{teacher_id}`

### 3. E2E

`live_e2e_teacher_flow_test.py` 新增 4 case 涵蓋本次驗證：
- 建立時段缺 `teacher_contract_id` → 422
- 合約屬於別的老師 → 400
- 合約 status=pending → 400
- 更新時段帶 pending 合約 → 400

順手修四個 E2E 跑不起來：`live_e2e_booking_flow_test.py`、`live_e2e_overtime_test.py`、`live_e2e_student_flow_test.py`、`live_e2e_courses_test.py` 在 `POST /students` 漏帶 `eng_name` + `phone`（commit `0070621` 改必填時只更新了 Playwright e2e，漏改 Python e2e）。

## Test plan

- [x] curl smoke：用 SQL 把 slot.teacher_contract_id 清成 NULL → 試上預約 → 400「此時段無有效教師有效合約，請重新建立時段」
- [x] curl：建立 slot 缺 contract_id → 422
- [x] curl：建立 slot 拿別老師合約 → 400「教師沒有 active 合約，無法建立時段」
- [x] curl：建立 slot 拿 pending 合約 → 400 同上
- [x] curl：`/teacher-slots/my-contracts`（teacher 登入）回應僅 `{id, contract_no}`
- [x] curl：`/bookings/options/teacher-contracts/{id}` 回應僅 `{id, contract_no}`
- [x] E2E `live_e2e_teacher_flow_test.py` 25/25 PASS
- [x] E2E `live_e2e_booking_flow_test.py` 38/38 PASS
- [x] E2E `live_e2e_overtime_test.py` 18/18 PASS
- [x] E2E `live_e2e_student_flow_test.py` 16/16 PASS
- [x] E2E `live_e2e_courses_test.py` 15/15 PASS
- [x] E2E `live_e2e_contracts_test.py` 35/35 PASS
- [x] E2E `live_e2e_leave_flow_test.py` 10/10 PASS
- [x] E2E `live_e2e_trial_to_formal_test.py` 13/13 PASS
- [x] E2E `live_e2e_permission_realtime_test.py` 17/17 PASS
- [x] 部署到 staging 驗證

## Notes

- DB 端**沒有**做 `ALTER COLUMN teacher_contract_id SET NOT NULL`。本機現存有 1 筆 slot 是 `NULL`，部署前可單獨清掉（軟刪）。後端 booking guard 已經會擋舊資料，不會再撞 500。
- 前端建 slot 表單需確認有合約下拉選單：可用 `GET /teacher-slots/my-contracts`（教師自己）或 `GET /bookings/options/teacher-contracts/{teacher_id}`（員工選擇老師後）；老師沒 active 合約 → 兩個 endpoint 都回 `data: []`，UI 應 disable 提交按鈕並提示「請先建立合約」。
- 沒做 N+1 → JOIN 改寫（之前討論過的 booking course_rate 驗證 loop），保留為下次 PR 處理。