### PR TITLE
fix(teacher-slots): 時段衝突回 409 而非 500

### DIFF
--- a/backend/app/api/v1/teacher_slots.py
+++ b/backend/app/api/v1/teacher_slots.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, Query, HTTPException
+import asyncpg
 from app.services.supabase_service import supabase_service
 from app.core.dependencies import get_current_user, CurrentUser, require_staff, require_page_permission, get_user_employee_id
 from app.schemas.teacher_slot import (
@@ -311,6 +312,8 @@ async def create_teacher_slot(
 
     except HTTPException:
         raise
+    except (asyncpg.exceptions.RaiseError, asyncpg.exceptions.ExclusionViolationError) as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"建立教師時段失敗: {str(e)}")
 
@@ -396,6 +399,8 @@ async def create_teacher_slots_batch(
 
     except HTTPException:
         raise
+    except (asyncpg.exceptions.RaiseError, asyncpg.exceptions.ExclusionViolationError) as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"批次建立教師時段失敗: {str(e)}")
 


### PR DESCRIPTION
## Summary
- POST `/api/v1/teacher-slots` 與 `/api/v1/teacher-slots/batch` 在遇到時段重疊時，原本因 trigger 拋出的 `RAISE EXCEPTION` 被 `except Exception` 吞下，回傳 HTTP 500
- 改為 catch `asyncpg.RaiseError` 與 `asyncpg.ExclusionViolationError`，回 HTTP 409 並保留原中文訊息

## 觸發 case
```
POST /api/v1/teacher-slots/batch
→ 時段衝突：該教師在 2026-04-29 已有 09:00:00 - 18:00:00 的授課時段，無法建立重疊時段
```
此為商業邏輯衝突，前端應依 4xx 顯示提示，不該觸發 5xx 告警/重試。

## Test plan
- [x] curl 驗證單筆建立衝突 → 409
- [x] curl 驗證批次建立衝突 → 409
- [x] 第一筆建立仍正常 200
- [x] 前端 UI 確認 409 訊息顯示正確