### PR TITLE
fix: Google Drive OAuth + Zoom start_url 防護 + Calendar attendee 放寬

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,8 @@ GOOGLE_DRIVE_OAUTH_CLIENT_SECRET=
 GOOGLE_DRIVE_OAUTH_REDIRECT_URI=http://localhost:8001/api/v1/google-drive/oauth/callback
 # 試上課錄影統一放到此 Drive 資料夾（留空 = 放預設資料夾）
 TRIAL_STUDENT_DRIVE_FOLDER_ID=
+# Google Calendar 同步開關（建立/更新/取消預約是否 push 到管理員 Calendar 並寄邀請信）
+GOOGLE_CALENDAR_SYNC_ENABLED=true
 
 ############
 # Zoom 錄影轉移（Google Drive via SQS + Lambda）

--- a/backend/app/api/v1/google_drive.py
+++ b/backend/app/api/v1/google_drive.py
@@ -8,6 +8,7 @@ from app.services.supabase_service import supabase_service
 from app.services.google_service import google_drive_service
 from app.core.dependencies import CurrentUser, require_staff, get_current_user
 from app.schemas.response import BaseResponse, DataResponse
+from app.schemas.google_drive import GoogleDriveOAuthUrlResponse, GoogleDriveStatusResponse
 from app.config import settings
 from datetime import datetime, timezone, timedelta
 import logging
@@ -18,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 # ── OAuth 端點 ──
 
-@router.get("/oauth/authorize", response_model=DataResponse)
+@router.get("/oauth/authorize", response_model=GoogleDriveOAuthUrlResponse)
 async def get_oauth_authorize_url(
     current_user: CurrentUser = Depends(require_staff),
 ):
@@ -101,7 +102,7 @@ async def oauth_callback(
         return RedirectResponse(url=f"{settings.FRONTEND_URL}/zoom-accounts?google_drive=error")
 
 
-@router.get("/oauth/status", response_model=DataResponse)
+@router.get("/oauth/status", response_model=GoogleDriveStatusResponse)
 async def get_drive_status(
     current_user: CurrentUser = Depends(get_current_user),
 ):

--- a/backend/app/api/v1/zoom.py
+++ b/backend/app/api/v1/zoom.py
@@ -431,6 +431,9 @@ async def batch_get_meetings_by_bookings(
                 item["teacher_id"] = str(item["teacher_id"])
             item["account_name"] = acct_map.get(str(row.get("zoom_account_id")))
             item["teacher_name"] = teacher_map.get(str(row.get("teacher_id")))
+            # start_url 含 ZAK，等同 host 完整權限，僅 staff 可見
+            if not current_user.is_staff():
+                item["start_url"] = None
             result[bid] = ZoomMeetingLogResponse(**item).model_dump(mode="json")
 
         return {"success": True, "message": "操作成功", "data": result}
@@ -490,6 +493,9 @@ async def get_meeting_by_booking(
             raise HTTPException(status_code=404, detail="此預約尚無 Zoom 會議")
 
         enriched = await enrich_meeting_log(logs[0])
+        # start_url 含 ZAK，等同 host 完整權限，僅 staff 可見
+        if not current_user.is_staff():
+            enriched["start_url"] = None
         return DataResponse(data=ZoomMeetingLogResponse(**enriched))
 
     except HTTPException:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -103,6 +103,9 @@ class Settings(BaseSettings):
     def google_drive_oauth_configured(self) -> bool:
         return bool(self.GOOGLE_DRIVE_OAUTH_CLIENT_ID and self.GOOGLE_DRIVE_OAUTH_CLIENT_SECRET)
 
+    # Google Calendar 同步（建立/更新/取消預約時 push 到管理員 Calendar 並寄邀請信）
+    GOOGLE_CALENDAR_SYNC_ENABLED: bool = True
+
     # 試上課錄影統一放到此資料夾（留空 = 放預設資料夾）
     TRIAL_STUDENT_DRIVE_FOLDER_ID: str = ""
 

--- a/backend/app/schemas/google_drive.py
+++ b/backend/app/schemas/google_drive.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class GoogleDriveOAuthUrlResponse(BaseModel):
+    """Google Drive OAuth 授權 URL 回應"""
+    success: bool = True
+    authorize_url: str
+
+
+class GoogleDriveStatusResponse(BaseModel):
+    """Google Drive 綁定狀態回應"""
+    success: bool = True
+    is_linked: bool = False
+    drive_mode: Optional[str] = None
+    google_email: Optional[str] = None
+    drive_folder_id: Optional[str] = None
+    linked_at: Optional[str] = None

--- a/backend/app/services/google_service.py
+++ b/backend/app/services/google_service.py
@@ -23,10 +23,6 @@ CALENDAR_API_BASE = "https://www.googleapis.com/calendar/v3"
 CALENDAR_TIMEZONE = "Asia/Taipei"
 
 
-def is_gmail(email: str) -> bool:
-    return email.lower().endswith("@gmail.com")
-
-
 class GoogleService:
 
     # ============================================================
@@ -194,23 +190,23 @@ class GoogleService:
             logger.warning("Google Calendar: 無可用 OAuth token，跳過同步")
             return False
 
-        gmail_attendees = []
+        attendees = []
         email_role_map = {}
-        if student_email and is_gmail(student_email):
-            gmail_attendees.append(student_email)
+        if student_email:
+            attendees.append(student_email)
             email_role_map[student_email] = "student"
-        if teacher_email and is_gmail(teacher_email):
-            gmail_attendees.append(teacher_email)
+        if teacher_email:
+            attendees.append(teacher_email)
             email_role_map[teacher_email] = "teacher"
 
-        if not gmail_attendees:
-            logger.info(f"Booking {booking_id}: 無 Gmail attendee，跳過 Calendar 同步")
+        if not attendees:
+            logger.info(f"Booking {booking_id}: 無 attendee email，跳過 Calendar 同步")
             return False
 
         body = self._build_calendar_event(
             summary=summary, description=description,
             date=date, start_time=start_time, end_time=end_time,
-            attendee_emails=gmail_attendees,
+            attendee_emails=attendees,
         )
 
         try:
@@ -230,7 +226,7 @@ class GoogleService:
             if not event_id:
                 return False
 
-            for email in gmail_attendees:
+            for email in attendees:
                 await supabase_service.table_insert(
                     table="booking_calendar_events",
                     data={
@@ -242,7 +238,7 @@ class GoogleService:
                     },
                 )
 
-            logger.info(f"Booking {booking_id}: Calendar 事件建立成功 (event={event_id}, attendees={gmail_attendees})")
+            logger.info(f"Booking {booking_id}: Calendar 事件建立成功 (event={event_id}, attendees={attendees})")
             return True
 
         except Exception as e:
@@ -275,16 +271,16 @@ class GoogleService:
 
         event_id = records[0]["calendar_event_id"]
 
-        gmail_attendees = []
-        if student_email and is_gmail(student_email):
-            gmail_attendees.append(student_email)
-        if teacher_email and is_gmail(teacher_email):
-            gmail_attendees.append(teacher_email)
+        attendees = []
+        if student_email:
+            attendees.append(student_email)
+        if teacher_email:
+            attendees.append(teacher_email)
 
         body = self._build_calendar_event(
             summary=summary, description=description,
             date=date, start_time=start_time, end_time=end_time,
-            attendee_emails=gmail_attendees,
+            attendee_emails=attendees,
         )
 
         try:

--- a/backend/app/services/google_service.py
+++ b/backend/app/services/google_service.py
@@ -185,6 +185,9 @@ class GoogleService:
         teacher_email: Optional[str],
     ) -> bool:
         """建立 Calendar 事件並邀請 Gmail 用戶"""
+        if not settings.GOOGLE_CALENDAR_SYNC_ENABLED:
+            return False
+
         token = await self.get_active_token()
         if not token:
             logger.warning("Google Calendar: 無可用 OAuth token，跳過同步")
@@ -257,6 +260,9 @@ class GoogleService:
         teacher_email: Optional[str],
     ) -> bool:
         """更新已同步的 Calendar 事件"""
+        if not settings.GOOGLE_CALENDAR_SYNC_ENABLED:
+            return False
+
         token = await self.get_active_token()
         if not token:
             return False
@@ -311,6 +317,9 @@ class GoogleService:
 
     async def cancel_calendar_event(self, booking_id: str) -> bool:
         """取消已同步的 Calendar 事件"""
+        if not settings.GOOGLE_CALENDAR_SYNC_ENABLED:
+            return False
+
         token = await self.get_active_token()
         if not token:
             return False


### PR DESCRIPTION
此 PR 包含三個獨立修正，全屬 Zoom/Google integration 範疇。

---

## 1. Google Drive OAuth /authorize 與 /status 回應結構

### 問題
點 Google Drive 綁定按鈕沒反應 — 前端打 \`/api/v1/google-drive/oauth/authorize\` 拿到 200 但沒跳轉 Google 授權頁。

### 根因
\`backend/app/api/v1/google_drive.py\` 兩支 endpoint 用通用 \`DataResponse\` 當 response_model，但 handler 回 \`{authorize_url}\` / \`{is_linked, ...}\`。FastAPI 過濾掉 schema 沒定義的欄位，響應變 \`{success, message, data: null}\`，前端 \`data?.authorize_url\` undefined 導致靜默失敗。

### 修法
新增 \`backend/app/schemas/google_drive.py\`：
- \`GoogleDriveOAuthUrlResponse\` (success + authorize_url)
- \`GoogleDriveStatusResponse\` (success + 狀態欄位)

兩 endpoint 改用對應 response_model。**前端不用改**。

---

## 2. Zoom start_url 僅 staff 可見

### 問題
\`start_url\` 含 ZAK token，等同 host 完整權限 (踢人/結束會議/控制錄影)。原本對所有角色都回傳：
- GET /api/v1/zoom/meetings/{booking_id}
- POST /api/v1/zoom/meetings/batch

學生/老師也能拿到 start_url，屬資料外洩。

### 修法
非 staff 取得時將 \`start_url\` 強制設為 None。其他欄位 (join_url/passcode 等) 不受影響，老師/學生仍可正常以 participant 身份進場。前端目前無任何元件讀取 start_url，故無需更動。

---

## 3. Calendar attendee 放寬，老師非 Gmail 也納入

### 問題
\`google_service.py\` 的 \`is_gmail()\` filter 把學生與老師都限定在 \`@gmail.com\`，公司網域老師被擋掉收不到日曆邀請信。

### 修法
移除 \`is_gmail()\` helper，create/update 兩處 filter 拿掉。任何非空 email 皆加入 Calendar attendee。Google Calendar 對非 Gmail 收件人仍會寄邀請信。

---

## 驗證 (curl)

\`\`\`
[Google Drive]
/oauth/authorize → {"success":true,"authorize_url":"https://accounts.google.com/..."}
/oauth/status   → {"success":true,"is_linked":true,"drive_mode":"oauth",...}

[Zoom start_url]
STAFF   → start_url=https://zoom.us/s/...?zak=...
TEACHER → start_url=None
STUDENT → start_url=None

[Calendar attendees] — 待 OAuth 重新綁定後實測
非 Gmail teacher_email 進到 attendee 列表
\`\`\`

## Test plan
- [x] curl 驗證 google-drive endpoints
- [x] curl 驗證 staff 拿到 start_url，老師/學生為 None
- [x] backend 啟動無 import error (移除 is_gmail 後)
- [ ] 前端按「綁定 Google Drive」確認跳轉 Google OAuth 頁
- [ ] 重新綁 OAuth 後實測非 Gmail 老師收到 Calendar 邀請