### PR TITLE
fix(bookings): 確認預約時 Zoom 建立失敗則 rollback 狀態並回 4xx

### DIFF
--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -1663,41 +1663,65 @@ async def update_booking(
                 )
 
         # Zoom 整合：狀態變更時觸發
+        # confirmed：同步等 Zoom 建立完，失敗則 rollback 狀態回 old_status 並回 409
+        # cancelled/pending：刪除 Zoom 會議走非同步（即使失敗也不擋 user）
         new_status = update_data.get("booking_status")
         if new_status and new_status != old_status:
-            try:
-                from app.services.zoom_service import zoom_service
-                from app.config import settings as app_settings
-                if app_settings.zoom_enabled:
-                    if new_status == "confirmed":
-                        # 確認 → 建立 Zoom 會議
-                        booking_date_val = existing[0].get("booking_date") or result.get("booking_date")
-                        start_time_val = existing[0].get("start_time") or result.get("start_time")
-                        end_time_val = existing[0].get("end_time") or result.get("end_time")
-                        teacher_id_val = existing[0].get("teacher_id")
-                        if booking_date_val and start_time_val and end_time_val and teacher_id_val:
-                            if isinstance(booking_date_val, str):
-                                booking_date_val = date.fromisoformat(booking_date_val)
-                            if isinstance(start_time_val, str):
-                                start_time_val = time.fromisoformat(start_time_val)
-                            if isinstance(end_time_val, str):
-                                end_time_val = time.fromisoformat(end_time_val)
-                            asyncio.create_task(
-                                zoom_service.create_meeting_for_booking(
-                                    booking_id=booking_id,
-                                    teacher_id=teacher_id_val,
-                                    booking_date=booking_date_val,
-                                    start_time_val=start_time_val,
-                                    end_time_val=end_time_val,
-                                )
+            from app.services.zoom_service import zoom_service
+            from app.config import settings as app_settings
+            if app_settings.zoom_enabled:
+                if new_status == "confirmed":
+                    booking_date_val = existing[0].get("booking_date") or result.get("booking_date")
+                    start_time_val = existing[0].get("start_time") or result.get("start_time")
+                    end_time_val = existing[0].get("end_time") or result.get("end_time")
+                    teacher_id_val = existing[0].get("teacher_id")
+                    zoom_result = None
+                    zoom_err: Optional[Exception] = None
+                    if booking_date_val and start_time_val and end_time_val and teacher_id_val:
+                        if isinstance(booking_date_val, str):
+                            booking_date_val = date.fromisoformat(booking_date_val)
+                        if isinstance(start_time_val, str):
+                            start_time_val = time.fromisoformat(start_time_val)
+                        if isinstance(end_time_val, str):
+                            end_time_val = time.fromisoformat(end_time_val)
+                        try:
+                            zoom_result = await zoom_service.create_meeting_for_booking(
+                                booking_id=booking_id,
+                                teacher_id=teacher_id_val,
+                                booking_date=booking_date_val,
+                                start_time_val=start_time_val,
+                                end_time_val=end_time_val,
                             )
-                    elif new_status in ("cancelled", "pending"):
-                        # 取消或退回待確認 → 刪除已存在的 Zoom 會議
-                        asyncio.create_task(
-                            zoom_service.cancel_meeting_for_booking(booking_id)
+                        except Exception as e:
+                            zoom_err = e
+
+                    if zoom_result is None:
+                        # 還原狀態
+                        await supabase_service.table_update(
+                            table="bookings",
+                            data={"booking_status": old_status},
+                            filters={"id": booking_id},
                         )
-            except Exception as zoom_err:
-                logging.getLogger(__name__).warning(f"Zoom 會議狀態變更觸發失敗: {zoom_err}")
+                        if zoom_err is not None:
+                            logging.getLogger(__name__).error(
+                                f"確認預約 → Zoom 建立例外，已 rollback: booking_id={booking_id} err={zoom_err}"
+                            )
+                            raise HTTPException(
+                                status_code=502,
+                                detail="Zoom 服務目前無法建立會議，請稍後再試。預約狀態保留為原狀態。",
+                            )
+                        logging.getLogger(__name__).warning(
+                            f"確認預約 → Zoom 帳號池無可用帳號，已 rollback: booking_id={booking_id}"
+                        )
+                        raise HTTPException(
+                            status_code=409,
+                            detail="該時段所有 Zoom 帳號皆被佔用，無法建立會議。請改選其他時段或先釋放衝突的時段，預約狀態保留為原狀態。",
+                        )
+                elif new_status in ("cancelled", "pending"):
+                    # 取消 / 退回待確認 → 刪除 Zoom 會議（非同步、失敗不擋）
+                    asyncio.create_task(
+                        zoom_service.cancel_meeting_for_booking(booking_id)
+                    )
 
         # 試上課完成：自動寫入「試上完成」獎金紀錄
         if new_status == "completed" and old_status != "completed":


### PR DESCRIPTION
## 問題

舊行為：\`PUT /api/v1/bookings/{id}\` 把 \`booking_status\` 改成 \`confirmed\` 時，透過 \`asyncio.create_task\` 非同步建立 Zoom 會議。建會議失敗（pool 全被佔用 / S2S token 失敗 / 等）只 log warning，**狀態仍會變成 confirmed**，但實際上沒有對應的 Zoom 會議 — 出現「狀態已確認但無會議」的不一致狀態。

## 修法

\`backend/app/api/v1/bookings.py\` 的 \`update_booking\`：

- **confirmed 轉換**：改為同步 \`await create_meeting_for_booking(...)\`：
  - 回傳 None → rollback \`booking_status\` 回 \`old_status\`，HTTP **409** + 明確訊息「該時段所有 Zoom 帳號皆被佔用…」
  - 拋例外（網路 / Zoom API） → rollback，HTTP **502** + 「Zoom 服務目前無法建立會議，請稍後再試。」
- **cancelled / pending 轉換**：保留原非同步 \`cancel_meeting_for_booking\`（取消失敗不應擋 user 取消預約）

## 驗證 (本地 curl)

setup：手動在 DB 兩個 active pool account 上插入 zoom_meeting_logs 占用目標時段，建立 pending booking。

\`\`\`
PUT /api/v1/bookings/{id} {"booking_status":"confirmed"}
→ HTTP 409
→ {"success":false, "detail":"該時段所有 Zoom 帳號皆被佔用，無法建立會議…", "error_code":"CONFLICT"}
→ DB booking_status 仍是 pending
→ 該 booking 無殘留 zoom_meeting_logs
\`\`\`

## 影響的既有測試

\`e2e/tests/group8-booking/booking.spec.ts:176\` (PUT 確認預約 status pending → confirmed) 在 Zoom pool 已被歷史資料占用的環境會開始失敗（之前 fire-and-forget 拿不到失敗訊號）。建議後續：
- 該測試切換到較不衝堂的時段（22:00 之類）
- 或於 setup 中清乾淨 zoom_meeting_logs 占位 row

## Test plan
- [x] 本地 curl 驗證 conflict → 409 + 狀態 rollback
- [x] dev 部署後驗證 booking confirm 行為
- [x] 補新 e2e（另案，spec 已草稿但未進此 PR）