### PR TITLE
fix(schemas): 學生 birth_date 空字串自動轉 None

### DIFF
--- a/backend/app/schemas/_validators.py
+++ b/backend/app/schemas/_validators.py
@@ -1,0 +1,24 @@
+"""共用 Pydantic 型別 / 驗證輔助。
+
+前端表單常以空字串作為「未填」的預設值；Pydantic 對 Optional[date]/[datetime]
+型別收到 "" 會嘗試解析失敗回 422 「Input should be a valid date or datetime,
+input is too short」。為了讓使用者體驗一致，輸入用 schema 的 Optional 日期欄位
+應改用 OptionalDate / OptionalDateTime 這兩個 Annotated 型別，會在驗證前把空字串
+轉成 None。
+
+回應用 schema 不需動（資料由後端產生，不會有空字串問題）。
+"""
+from datetime import date, datetime
+from typing import Annotated, Optional
+
+from pydantic import BeforeValidator
+
+
+def _empty_str_to_none(value):
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    return value
+
+
+OptionalDate = Annotated[Optional[date], BeforeValidator(_empty_str_to_none)]
+OptionalDateTime = Annotated[Optional[datetime], BeforeValidator(_empty_str_to_none)]

--- a/backend/app/schemas/student.py
+++ b/backend/app/schemas/student.py
@@ -2,6 +2,8 @@ from pydantic import BaseModel, EmailStr, Field
 from typing import Optional
 from datetime import datetime, date
 
+from app.schemas._validators import OptionalDate
+
 
 class StudentCreate(BaseModel):
     """建立學生"""
@@ -11,7 +13,7 @@ class StudentCreate(BaseModel):
     email: EmailStr = Field(..., description="Email")
     phone: str = Field(..., min_length=1, max_length=20, description="電話（必填）")
     address: Optional[str] = Field(None, description="地址")
-    birth_date: Optional[date] = Field(None, description="生日")
+    birth_date: OptionalDate = Field(None, description="生日（空字串自動轉 None）")
     id_number: Optional[str] = Field(None, max_length=20, description="身分證字號")
     student_type: str = Field("formal", description="學生類型 (formal/trial)")
     is_active: bool = Field(True, description="是否啟用")
@@ -38,7 +40,7 @@ class StudentUpdate(BaseModel):
     email: Optional[EmailStr] = None
     phone: Optional[str] = Field(None, max_length=20)
     address: Optional[str] = None
-    birth_date: Optional[date] = None
+    birth_date: OptionalDate = None
     id_number: Optional[str] = Field(None, max_length=20)
     student_type: Optional[str] = Field(None, description="學生類型 (formal/trial)")
     is_active: Optional[bool] = None


### PR DESCRIPTION
## 問題

前端表單未填生日時送出 \`birth_date=\"\"\` → Pydantic \`Optional[date]\` 解析空字串失敗 → 422 「Input should be a valid date or datetime, input is too short」。

影響 \`frontend/\` Vue 端的學生新增/編輯（\`frontend-dennis/\` 有手動 sanitize 所以不受影響）。

## 修法

新增共用型別 \`backend/app/schemas/_validators.py\`：
- \`OptionalDate\` / \`OptionalDateTime\` — \`Annotated[Optional[date], BeforeValidator(...)]\`
- 收到空字串（含純空白）→ 轉 None
- 其他值（合法日期 / 真正不合法字串）維持原本 Pydantic 驗證流程

套用：
- \`StudentCreate.birth_date\`
- \`StudentUpdate.birth_date\`

## 驗證 (本地 curl)

\`\`\`
birth_date=\"\"        → HTTP 200, birth_date=None
birth_date 欄位省略    → HTTP 200, birth_date=None
birth_date=\"2010-01-15\" → HTTP 200, birth_date=2010-01-15
birth_date=\"abc\"     → HTTP 422 (真不合法仍擋)
\`\`\`

## 後續可擴展

其他輸入 schema 有相同潛在問題，建議遇到再套用 \`OptionalDate\` 替換：
- \`auth.py:30\` SignUpRequest.birth_date
- \`teacher_contract.py:214,215\` start_date/end_date
- \`teacher_bonus.py:31,54\` bonus_date

未一次擴展是因為避免 scope 擴大；helper 已建好，未來一行替換即可。

## Test plan
- [x] curl 驗證四種輸入 case
- [x] 前端 \`/student\` 新增學生不填生日點儲存，預期成功
- [x] 前端編輯學生清空生日儲存，預期成功