### PR TITLE
feat(infra): logger 改善 + TZ Taipei + slot 409 + is_active enforcement + purge 腳本

### DIFF
--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -1067,25 +1067,25 @@ async def create_booking(
             # 教師和其他角色不能建立預約
             raise HTTPException(status_code=403, detail="無權建立預約")
 
-        # 驗證學生存在
+        # 驗證學生存在且未停用
         student = await supabase_service.table_select(
             table="students",
             select="id,name,student_type",
-            filters={"id": data.student_id, "is_deleted": "eq.false"},
+            filters={"id": data.student_id, "is_deleted": "eq.false", "is_active": "eq.true"},
         )
         if not student:
-            raise HTTPException(status_code=400, detail="學生不存在")
+            raise HTTPException(status_code=400, detail="學生不存在或已停用")
 
         is_trial = student[0].get("student_type") == "trial"
 
-        # 驗證教師存在
+        # 驗證教師存在且未停用
         teacher = await supabase_service.table_select(
             table="teachers",
             select="id,name,teacher_level",
-            filters={"id": data.teacher_id, "is_deleted": "eq.false"},
+            filters={"id": data.teacher_id, "is_deleted": "eq.false", "is_active": "eq.true"},
         )
         if not teacher:
-            raise HTTPException(status_code=400, detail="教師不存在")
+            raise HTTPException(status_code=400, detail="教師不存在或已停用")
 
         # 驗證課程存在
         course = await supabase_service.table_select(
@@ -2040,25 +2040,25 @@ async def batch_create_bookings(
         elif not current_user.is_staff():
             raise HTTPException(status_code=403, detail="無權建立預約")
 
-        # 驗證學生存在
+        # 驗證學生存在且未停用
         student = await supabase_service.table_select(
             table="students",
             select="id,name,student_type",
-            filters={"id": data.student_id, "is_deleted": "eq.false"},
+            filters={"id": data.student_id, "is_deleted": "eq.false", "is_active": "eq.true"},
         )
         if not student:
-            raise HTTPException(status_code=400, detail="學生不存在")
+            raise HTTPException(status_code=400, detail="學生不存在或已停用")
 
         is_trial = student[0].get("student_type") == "trial"
 
-        # 驗證教師存在
+        # 驗證教師存在且未停用
         teacher = await supabase_service.table_select(
             table="teachers",
             select="id,name,teacher_level",
-            filters={"id": data.teacher_id, "is_deleted": "eq.false"},
+            filters={"id": data.teacher_id, "is_deleted": "eq.false", "is_active": "eq.true"},
         )
         if not teacher:
-            raise HTTPException(status_code=400, detail="教師不存在")
+            raise HTTPException(status_code=400, detail="教師不存在或已停用")
 
         # 課程 ID：優先使用前端傳入的 course_id
         course_id = data.course_id

--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -446,10 +446,17 @@ async def enrich_booking_with_relations(booking: dict) -> dict:
     if booking.get("student_id"):
         student = await supabase_service.table_select(
             table="students",
-            select="name",
+            select="name,student_no,eng_name",
             filters={"id": booking["student_id"]},
         )
-        booking["student_name"] = student[0]["name"] if student else None
+        if student:
+            booking["student_name"] = student[0]["name"]
+            booking["student_no"] = student[0].get("student_no")
+            booking["student_eng_name"] = student[0].get("eng_name")
+        else:
+            booking["student_name"] = None
+            booking["student_no"] = None
+            booking["student_eng_name"] = None
 
     # 取得教師名稱
     if booking.get("teacher_id"):
@@ -719,6 +726,8 @@ async def list_bookings(
                             AND tbr.is_deleted = FALSE) AS is_trial_to_formal,
                    -- 關聯名稱
                    s.name AS student_name,
+                   s.student_no,
+                   s.eng_name AS student_eng_name,
                    t.name AS teacher_name,
                    c.course_name AS course_name,
                    c.duration_minutes,

--- a/backend/app/api/v1/leave_records.py
+++ b/backend/app/api/v1/leave_records.py
@@ -6,7 +6,7 @@ from app.schemas.leave_record import (
 )
 from app.schemas.response import BaseResponse, DataResponse
 from typing import Optional
-from datetime import datetime, date, timedelta
+from datetime import datetime, date
 import math
 import logging
 
@@ -190,7 +190,7 @@ async def create_leave_record(
         if hasattr(booking_start_str, 'isoformat'):
             booking_start_str = booking_start_str.isoformat()
         class_start_dt = datetime.strptime(f"{booking_date_str} {booking_start_str}", "%Y-%m-%d %H:%M:%S")
-        now = datetime.utcnow() + timedelta(hours=8)  # UTC+8 台灣時間
+        now = datetime.now()  # container TZ=Asia/Taipei，naive Taipei
 
         hours_before = (class_start_dt - now).total_seconds() / 3600
 

--- a/backend/app/api/v1/student_contracts.py
+++ b/backend/app/api/v1/student_contracts.py
@@ -136,9 +136,17 @@ async def enrich_contract_with_relations(contract: dict) -> dict:
     )
     contract["leave_records"] = leave_records
 
-    # 計算緊急請假額度
-    total_lessons = contract.get("total_lessons", 0)
-    contract["emergency_leave_quota"] = math.ceil(total_lessons * 0.2) if total_lessons else 0
+    # 計算緊急請假額度（堂數 = total_lessons + 補償堂數）
+    total_lessons = contract.get("total_lessons", 0) or 0
+    compensation_total = sum(
+        int(d.get("amount", 0) or 0)
+        for d in enriched_details
+        if d.get("detail_type") == "compensation"
+    )
+    effective_lessons = total_lessons + compensation_total
+    contract["emergency_leave_quota"] = math.ceil(effective_lessons * 0.2) if effective_lessons else 0
+    used_em = contract.get("used_emergency_leave_count", 0) or 0
+    contract["remaining_emergency_leave_count"] = max(0, contract["emergency_leave_quota"] - used_em)
 
     # 取得附約列表
     addendums = await supabase_service.table_select(
@@ -403,8 +411,16 @@ async def list_student_contracts(
             contract["student_id_number"] = student.get("id_number") if student else None
             contract["details"] = detail_map.get(str(cid), [])
             contract["leave_records"] = leave_map.get(str(cid), [])
-            total_lessons = contract.get("total_lessons", 0)
-            contract["emergency_leave_quota"] = math.ceil(total_lessons * 0.2) if total_lessons else 0
+            total_lessons = contract.get("total_lessons", 0) or 0
+            compensation_total = sum(
+                int(d.get("amount", 0) or 0)
+                for d in contract["details"]
+                if d.get("detail_type") == "compensation"
+            )
+            effective_lessons = total_lessons + compensation_total
+            contract["emergency_leave_quota"] = math.ceil(effective_lessons * 0.2) if effective_lessons else 0
+            used_em = contract.get("used_emergency_leave_count", 0) or 0
+            contract["remaining_emergency_leave_count"] = max(0, contract["emergency_leave_quota"] - used_em)
             addendums = addendum_map.get(str(cid), [])
             for a in addendums:
                 a["parent_contract_no"] = contract.get("contract_no")

--- a/backend/app/api/v1/student_contracts.py
+++ b/backend/app/api/v1/student_contracts.py
@@ -1318,7 +1318,10 @@ async def confirm_student_contract_upload(
 ):
     """確認學生合約檔案上傳完成（僅限員工）
 
-    前端直接上傳 S3 成功後呼叫此 API，更新 DB 並將狀態改為 active。
+    前端直接上傳 S3 成功後呼叫此 API，更新 DB。
+    狀態翻 active 行為：
+      - 一般 (formal) 學生：上傳完成後自動翻 active（既有行為）
+      - trial 學生：維持 pending，等轉正流程才 activate（避免破壞轉正前置條件）
     """
     try:
         # 檢查合約是否存在
@@ -1330,9 +1333,21 @@ async def confirm_student_contract_upload(
         if not existing:
             raise HTTPException(status_code=404, detail="學生合約不存在")
 
-        # 檢查 active 合約唯一性（上傳確認會自動設為 active）
         check_student_id = existing[0].get("student_id")
+
+        # 判斷學生類型，決定是否要翻 active
+        auto_activate = True
         if check_student_id:
+            student_rows = await supabase_service.table_select(
+                table="students",
+                select="student_type",
+                filters={"id": check_student_id, "is_deleted": "eq.false"},
+            )
+            if student_rows and student_rows[0].get("student_type") == "trial":
+                auto_activate = False
+
+        # 只在會翻 active 時才檢查 active 合約唯一性
+        if auto_activate and check_student_id:
             conflict = await check_student_active_conflict(check_student_id, exclude_contract_id=contract_id)
             if conflict:
                 raise HTTPException(
@@ -1355,13 +1370,14 @@ async def confirm_student_contract_upload(
         # 取得員工 ID
         employee_id = await get_user_employee_id(current_user.user_id)
 
-        # 更新 DB：檔案資訊 + 狀態改為 active
+        # 更新 DB：檔案資訊 +（視情況）狀態改為 active
         update_data = {
             "contract_file_path": body.storage_path,
             "contract_file_name": body.file_name,
             "contract_file_uploaded_at": datetime.utcnow().isoformat(),
-            "contract_status": "active",
         }
+        if auto_activate:
+            update_data["contract_status"] = "active"
         if employee_id:
             update_data["contract_file_uploaded_by"] = employee_id
 
@@ -1375,8 +1391,9 @@ async def confirm_student_contract_upload(
             raise HTTPException(status_code=500, detail="更新合約資訊失敗")
 
         enriched = await enrich_contract_with_relations(result)
+        msg = "合約檔案上傳成功，狀態已更新為生效中" if auto_activate else "合約檔案上傳成功（試上學生：合約維持 pending，轉正時再生效）"
         return DataResponse(
-            message="合約檔案上傳成功，狀態已更新為生效中",
+            message=msg,
             data=StudentContractResponse(**enriched)
         )
 

--- a/backend/app/api/v1/student_contracts.py
+++ b/backend/app/api/v1/student_contracts.py
@@ -493,11 +493,21 @@ async def create_student_contract(
         # 驗證學生存在
         student = await supabase_service.table_select(
             table="students",
-            select="id,name",
+            select="id,name,student_type",
             filters={"id": data.student_id, "is_deleted": "eq.false"},
         )
         if not student:
             raise HTTPException(status_code=400, detail="學生不存在")
+
+        # 試上學生只能建 pending 合約，active 必須透過轉正流程
+        if (
+            data.contract_status == ContractStatus.active
+            and student[0].get("student_type") == "trial"
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="試上學生合約只能透過轉正流程啟用，請先建立 pending 合約",
+            )
 
         # 檢查 active 合約唯一性
         if data.contract_status == ContractStatus.active:
@@ -577,6 +587,21 @@ async def update_student_contract(
 
         if not existing:
             raise HTTPException(status_code=404, detail="學生合約不存在")
+
+        # 試上學生不能透過 update 把合約改成 active（必須走轉正流程）
+        if data.contract_status == ContractStatus.active:
+            check_student_id = data.student_id or existing[0].get("student_id")
+            if check_student_id:
+                stu = await supabase_service.table_select(
+                    table="students",
+                    select="student_type",
+                    filters={"id": check_student_id, "is_deleted": "eq.false"},
+                )
+                if stu and stu[0].get("student_type") == "trial":
+                    raise HTTPException(
+                        status_code=400,
+                        detail="試上學生合約只能透過轉正流程啟用",
+                    )
 
         # 檢查 active 合約唯一性
         if data.contract_status == ContractStatus.active:

--- a/backend/app/api/v1/student_teacher_preferences.py
+++ b/backend/app/api/v1/student_teacher_preferences.py
@@ -86,7 +86,7 @@ async def get_course_options(
         # 查詢課程詳情
         pool = supabase_service.pool
         courses = await pool.fetch(
-            "SELECT id, course_name FROM courses WHERE id = ANY($1) AND is_deleted = FALSE",
+            "SELECT id, course_name FROM courses WHERE id = ANY($1) AND is_deleted = FALSE AND is_active = TRUE",
             course_ids,
         )
         return {"success": True, "message": "操作成功", "data": [{"id": str(c["id"]), "course_name": c["course_name"]} for c in courses]}

--- a/backend/app/api/v1/students.py
+++ b/backend/app/api/v1/students.py
@@ -240,13 +240,17 @@ async def convert_to_formal(
 ):
     """試上學生轉正式學生（僅限員工）
 
+    新流程（必須先建好 pending 合約並上傳 PDF）：
     1. 驗證學生為 trial 類型
-    2. 更新 student_type → formal
-    3. 建立 student_contracts（status=active）
-    4. 若提供 teacher_id，記錄轉正獎金
+    2. 驗證合約：屬於該學生、status=pending、已上傳 PDF
+    3. 驗證 booking（若提供）為已完成的試上、未轉正
+    4. Transaction：student → formal、contract → active
+    5. 若提供 teacher_id，記錄轉正差額獎金（失敗寫 system_alerts，不擋流程）
     """
     try:
-        # 1. 驗證學生存在且為 trial
+        pool = supabase_service.pool
+
+        # 1. 驗證學生
         students = await supabase_service.table_select(
             table="students", select=STUDENT_SELECT,
             filters={"id": student_id, "is_deleted": "eq.false"},
@@ -258,9 +262,34 @@ async def convert_to_formal(
         if student.get("student_type") != "trial":
             raise HTTPException(status_code=400, detail="此學生非試上學生，無法執行轉正")
 
-        # 1.5 驗證 booking_id 為 trial、已完成、且未轉正
+        # 2. 驗證合約
+        try:
+            sc_uuid = uuid.UUID(data.student_contract_id)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="合約 ID 格式錯誤")
+
+        contract_rows = await pool.fetch(
+            """
+            SELECT id, contract_no, student_id, contract_status,
+                   start_date, end_date, total_lessons, remaining_lessons,
+                   contract_file_path, notes, created_at
+            FROM student_contracts
+            WHERE id = $1 AND is_deleted = FALSE AND contract_status = 'pending'
+            """,
+            sc_uuid,
+        )
+        if not contract_rows:
+            raise HTTPException(status_code=404, detail="找不到 pending 合約（合約不存在、已生效或已刪除）")
+
+        contract = dict(contract_rows[0])
+        if str(contract["student_id"]) != student_id:
+            raise HTTPException(status_code=400, detail="合約不屬於此學生")
+        if not contract.get("contract_file_path"):
+            raise HTTPException(status_code=400, detail="合約必須先上傳 PDF 才能轉正")
+
+        # 3. 驗證 booking
         if data.booking_id:
-            booking_rows = await supabase_service.pool.fetch(
+            booking_rows = await pool.fetch(
                 """
                 SELECT id, booking_type, booking_status, is_trial_to_formal
                 FROM bookings_view
@@ -278,43 +307,43 @@ async def convert_to_formal(
             if bk["is_trial_to_formal"]:
                 raise HTTPException(status_code=400, detail="此預約已被標記為轉正")
 
-        # 2. 更新 student_type → formal, student_status → active
-        updated_student = await supabase_service.table_update(
-            table="students",
-            data={"student_type": "formal", "student_status": "active"},
+        employee_id = await get_user_employee_id(current_user.user_id)
+
+        # 4. Transaction：學生 + 合約狀態同步翻轉
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    """
+                    UPDATE students
+                    SET student_type = 'formal', student_status = 'active', updated_at = NOW()
+                    WHERE id = $1
+                    """,
+                    uuid.UUID(student_id),
+                )
+                await conn.execute(
+                    """
+                    UPDATE student_contracts
+                    SET contract_status = 'active', updated_at = NOW()
+                    WHERE id = $1
+                    """,
+                    sc_uuid,
+                )
+
+        # 重新撈最新狀態（用 table_select 確保 UUID/date → str）
+        updated_student_rows = await supabase_service.table_select(
+            table="students", select=STUDENT_SELECT,
             filters={"id": student_id},
         )
-        if not updated_student:
-            raise HTTPException(status_code=500, detail="更新學生類型失敗")
-
-        # 3. 建立 student_contracts
-        employee_id = await get_user_employee_id(current_user.user_id)
-        contract_data = {
-            "contract_no": data.contract_no,
-            "student_id": student_id,
-            "contract_status": "active",
-            "start_date": data.start_date.isoformat(),
-            "end_date": data.end_date.isoformat(),
-            "total_lessons": data.total_lessons,
-            "total_amount": data.total_amount,
-            "remaining_lessons": data.total_lessons,
-            "total_leave_allowed": math.ceil(data.total_lessons * 0.2),
-            "notes": data.notes,
-        }
-        if employee_id:
-            contract_data["created_by"] = employee_id
-
-        contract = await supabase_service.table_insert(
-            table="student_contracts", data=contract_data
+        updated_contract_rows = await supabase_service.table_select(
+            table="student_contracts",
+            select="id,contract_no,student_id,contract_status,start_date,end_date,total_lessons,remaining_lessons,notes,created_at",
+            filters={"id": data.student_contract_id},
         )
-        if not contract:
-            raise HTTPException(status_code=500, detail="建立合約失敗")
 
-        # 4. 若提供 teacher_id，記錄轉正差額獎金
-        #    差額 = trial_to_formal_bonus - trial_completed_bonus
-        #    （試上完成獎金已在 booking completed 時發放）
+        # 5. 轉正差額獎金（失敗寫 alert）
         bonus_recorded = False
         bonus_amount = None
+        bonus_error: Optional[str] = None
         if data.teacher_id:
             try:
                 tc_list = await supabase_service.table_select(
@@ -326,40 +355,52 @@ async def convert_to_formal(
                         "is_deleted": "eq.false",
                     },
                 )
-                if tc_list:
+                if not tc_list:
+                    bonus_error = "教師沒有 active 合約，無法計算轉正獎金"
+                else:
                     formal_bonus = float(tc_list[0].get("trial_to_formal_bonus", 0) or 0)
                     completed_bonus = float(tc_list[0].get("trial_completed_bonus", 0) or 0)
-                    bonus_amount = formal_bonus - completed_bonus
-                    if bonus_amount < 0:
-                        bonus_amount = 0
+                    bonus_amount = max(0.0, formal_bonus - completed_bonus)
+                    bonus_data = {
+                        "teacher_id": data.teacher_id,
+                        "bonus_type": "trial_to_formal",
+                        "amount": bonus_amount,
+                        "bonus_date": date.today().isoformat(),
+                        "description": f"學生 {student.get('name', '')} 試上轉正獎金（差額）",
+                        "related_student_id": student_id,
+                    }
+                    if data.booking_id:
+                        bonus_data["related_booking_id"] = data.booking_id
+                    if employee_id:
+                        bonus_data["created_by"] = employee_id
+                    await supabase_service.table_insert(
+                        table="teacher_bonus_records", data=bonus_data,
+                    )
                     bonus_recorded = True
-                    # 寫入差額獎金紀錄
-                    try:
-                        bonus_data = {
-                            "teacher_id": data.teacher_id,
-                            "bonus_type": "trial_to_formal",
-                            "amount": bonus_amount,
-                            "bonus_date": date.today().isoformat(),
-                            "description": f"學生 {student.get('name', '')} 試上轉正獎金（差額）",
-                            "related_student_id": student_id,
-                        }
-                        if data.booking_id:
-                            bonus_data["related_booking_id"] = data.booking_id
-                        if employee_id:
-                            bonus_data["created_by"] = employee_id
-                        await supabase_service.table_insert(
-                            table="teacher_bonus_records", data=bonus_data
-                        )
-                    except Exception:
-                        pass  # 獎金寫入失敗不影響轉正流程
-            except Exception:
-                pass  # 獎金查詢失敗不影響轉正
+            except Exception as e:
+                bonus_error = f"獎金處理失敗：{e}"
+
+            if bonus_error:
+                from app.services.alert_service import alert_service
+                await alert_service.create(
+                    alert_type="trial_to_formal_bonus_failed",
+                    severity="error",
+                    title="轉正獎金寫入失敗",
+                    message=bonus_error,
+                    metadata={
+                        "student_id": student_id,
+                        "student_contract_id": data.student_contract_id,
+                        "teacher_id": data.teacher_id,
+                        "booking_id": data.booking_id,
+                    },
+                )
 
         return ConvertToFormalResponse(
-            student=StudentResponse(**updated_student),
-            contract=ConvertToFormalContractInfo(**contract),
+            student=StudentResponse(**updated_student_rows[0]),
+            contract=ConvertToFormalContractInfo(**updated_contract_rows[0]),
             bonus_recorded=bonus_recorded,
             bonus_amount=bonus_amount,
+            bonus_error=bonus_error,
         )
     except HTTPException:
         raise

--- a/backend/app/api/v1/teacher_slots.py
+++ b/backend/app/api/v1/teacher_slots.py
@@ -252,14 +252,14 @@ async def create_teacher_slot(
         elif not current_user.is_staff():
             raise HTTPException(status_code=403, detail="無權建立教師時段")
 
-        # 驗證教師存在
+        # 驗證教師存在且未停用
         teacher = await supabase_service.table_select(
             table="teachers",
             select="id,name",
-            filters={"id": data.teacher_id, "is_deleted": "eq.false"},
+            filters={"id": data.teacher_id, "is_deleted": "eq.false", "is_active": "eq.true"},
         )
         if not teacher:
-            raise HTTPException(status_code=400, detail="教師不存在")
+            raise HTTPException(status_code=400, detail="教師不存在或已停用")
 
         # 驗證教師合約：必須屬於該老師、active、未刪除
         contract = await supabase_service.table_select(
@@ -333,14 +333,14 @@ async def create_teacher_slots_batch(
         elif not current_user.is_staff():
             raise HTTPException(status_code=403, detail="無權建立教師時段")
 
-        # 驗證教師存在
+        # 驗證教師存在且未停用
         teacher = await supabase_service.table_select(
             table="teachers",
             select="id,name",
-            filters={"id": data.teacher_id, "is_deleted": "eq.false"},
+            filters={"id": data.teacher_id, "is_deleted": "eq.false", "is_active": "eq.true"},
         )
         if not teacher:
-            raise HTTPException(status_code=400, detail="教師不存在")
+            raise HTTPException(status_code=400, detail="教師不存在或已停用")
 
         # 驗證教師合約：必須屬於該老師、active、未刪除
         contract = await supabase_service.table_select(

--- a/backend/app/api/v1/teacher_slots.py
+++ b/backend/app/api/v1/teacher_slots.py
@@ -11,6 +11,7 @@ from app.schemas.response import BaseResponse, DataResponse, TeacherOption, Teac
 from typing import Optional, List
 from datetime import date, datetime, timedelta
 import math
+import uuid
 
 router = APIRouter(prefix="/teacher-slots", tags=["教師時段管理"])
 
@@ -131,6 +132,7 @@ async def list_teacher_slots(
         if slots:
             t_ids = list({s["teacher_id"] for s in slots if s.get("teacher_id")})
             tc_ids = list({s["teacher_contract_id"] for s in slots if s.get("teacher_contract_id")})
+            slot_ids = [s["id"] for s in slots]
             pool = supabase_service.pool
 
             import asyncio as _aio
@@ -138,16 +140,29 @@ async def list_teacher_slots(
 
             t_task = pool.fetch("SELECT id, name, teacher_no FROM teachers WHERE id = ANY($1)", t_ids) if t_ids else _empty()
             tc_task = pool.fetch("SELECT id, contract_no FROM teacher_contracts WHERE id = ANY($1)", tc_ids) if tc_ids else _empty()
+            bc_task = pool.fetch(
+                """
+                SELECT teacher_slot_id, COUNT(*) AS cnt
+                FROM bookings
+                WHERE teacher_slot_id = ANY($1)
+                  AND is_deleted = false
+                  AND booking_status != 'cancelled'
+                GROUP BY teacher_slot_id
+                """,
+                slot_ids,
+            )
 
-            t_rows, tc_rows = await _aio.gather(t_task, tc_task)
+            t_rows, tc_rows, bc_rows = await _aio.gather(t_task, tc_task, bc_task)
             t_map = {str(r["id"]): r for r in t_rows}
             tc_map = {str(r["id"]): r["contract_no"] for r in tc_rows}
+            bc_map = {str(r["teacher_slot_id"]): r["cnt"] for r in bc_rows}
 
             for slot in slots:
                 t = t_map.get(str(slot.get("teacher_id")))
                 slot["teacher_name"] = t["name"] if t else None
                 slot["teacher_no"] = t["teacher_no"] if t else None
                 slot["teacher_contract_no"] = tc_map.get(str(slot.get("teacher_contract_id")))
+                slot["booking_count"] = bc_map.get(str(slot["id"]), 0)
 
         return TeacherSlotListResponse(
             data=[TeacherSlotResponse(**s) for s in slots],
@@ -229,6 +244,16 @@ async def get_teacher_slot(
                 raise HTTPException(status_code=403, detail="此時段不可查看")
 
         enriched = await enrich_slot_with_relations(slot)
+
+        # 該 slot 有效預約數（非取消、非已刪除）
+        enriched["booking_count"] = await supabase_service.pool.fetchval(
+            """SELECT COUNT(*) FROM bookings
+               WHERE teacher_slot_id = $1
+                 AND is_deleted = false
+                 AND booking_status != 'cancelled'""",
+            uuid.UUID(slot["id"]),
+        )
+
         return DataResponse(data=TeacherSlotResponse(**enriched))
 
     except HTTPException:

--- a/backend/app/api/v1/teacher_slots.py
+++ b/backend/app/api/v1/teacher_slots.py
@@ -614,6 +614,8 @@ async def update_teacher_slots_batch(
 
     except HTTPException:
         raise
+    except (asyncpg.exceptions.RaiseError, asyncpg.exceptions.ExclusionViolationError) as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"批次更新教師時段失敗: {str(e)}")
 
@@ -764,6 +766,8 @@ async def update_teacher_slots_by_ids(
 
     except HTTPException:
         raise
+    except (asyncpg.exceptions.RaiseError, asyncpg.exceptions.ExclusionViolationError) as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"批次更新教師時段失敗: {str(e)}")
 
@@ -851,6 +855,8 @@ async def update_teacher_slot(
 
     except HTTPException:
         raise
+    except (asyncpg.exceptions.RaiseError, asyncpg.exceptions.ExclusionViolationError) as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"更新教師時段失敗: {str(e)}")
 

--- a/backend/app/api/v1/users.py
+++ b/backend/app/api/v1/users.py
@@ -6,6 +6,7 @@ from app.core.dependencies import (
 )
 from app.services.supabase_service import supabase_service
 from app.services.storage_service import storage_service
+from app.services.session_service import session_service
 from app.config import settings
 from app.schemas.response import DataResponse, PaginatedResponse, BaseResponse
 from app.schemas.user import UserProfile, AccountInfo, AccountUpdate
@@ -292,6 +293,12 @@ async def deactivate_user(
             data={"is_active": False},
             filters={"id": user_id},
         )
+
+        # 主動清掉現有 session，避免被停用帳號繼續用既有 cookie
+        try:
+            await session_service.destroy_all_user_sessions(user_id)
+        except Exception:
+            logger.exception("停用帳號後清除 session 失敗 (non-fatal)")
 
         return BaseResponse(message="帳號已停用")
     except HTTPException:

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -4,7 +4,9 @@ import logging
 import json
 import sys
 from contextvars import ContextVar
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+
+TAIPEI_TZ = timezone(timedelta(hours=8))
 
 # Per-request context variables
 request_id_var: ContextVar[str] = ContextVar("request_id", default="")
@@ -18,10 +20,10 @@ class JSONFormatter(logging.Formatter):
     """每行輸出一個 JSON object，自動帶入 request context"""
 
     def format(self, record: logging.LogRecord) -> str:
+        # UTC+8 + 秒精度
         log_entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": datetime.now(TAIPEI_TZ).isoformat(timespec="seconds"),
             "level": record.levelname,
-            "logger": record.name,
             "message": record.getMessage(),
         }
 

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -27,6 +27,11 @@ class JSONFormatter(logging.Formatter):
             "message": record.getMessage(),
         }
 
+        # HTTP status_code 獨立成頂層欄位 (由 LoggingMiddleware extra 傳入)
+        status_code = getattr(record, "status_code", None)
+        if status_code is not None:
+            log_entry["status_code"] = status_code
+
         # 從 contextvars 帶入 request context
         for key, var in [
             ("request_id", request_id_var),

--- a/backend/app/middleware/logging_middleware.py
+++ b/backend/app/middleware/logging_middleware.py
@@ -66,12 +66,13 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         # 添加 X-Request-ID header
         response.headers["X-Request-ID"] = rid
 
-        # 記錄 response log
+        # 記錄 response log；status_code 獨立欄位方便 log aggregator 過濾
         msg = f"{request.method} {path} {response.status_code} {elapsed_ms:.0f}ms"
+        extra = {"status_code": response.status_code}
         if elapsed_ms > 3000:
-            logger.warning(msg)
+            logger.warning(msg, extra=extra)
         else:
-            logger.info(msg)
+            logger.info(msg, extra=extra)
 
         # 重置 contextvars
         request_id_var.reset(tok_rid)

--- a/backend/app/schemas/_validators.py
+++ b/backend/app/schemas/_validators.py
@@ -1,0 +1,24 @@
+"""共用 Pydantic 型別 / 驗證輔助。
+
+前端表單常以空字串作為「未填」的預設值；Pydantic 對 Optional[date]/[datetime]
+型別收到 "" 會嘗試解析失敗回 422 「Input should be a valid date or datetime,
+input is too short」。為了讓使用者體驗一致，輸入用 schema 的 Optional 日期欄位
+應改用 OptionalDate / OptionalDateTime 這兩個 Annotated 型別，會在驗證前把空字串
+轉成 None。
+
+回應用 schema 不需動（資料由後端產生，不會有空字串問題）。
+"""
+from datetime import date, datetime
+from typing import Annotated, Optional
+
+from pydantic import BeforeValidator
+
+
+def _empty_str_to_none(value):
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    return value
+
+
+OptionalDate = Annotated[Optional[date], BeforeValidator(_empty_str_to_none)]
+OptionalDateTime = Annotated[Optional[datetime], BeforeValidator(_empty_str_to_none)]

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -117,6 +117,8 @@ class BookingResponse(BaseModel):
     updated_at: Optional[datetime] = None
     # 關聯資料
     student_name: Optional[str] = None
+    student_no: Optional[str] = None
+    student_eng_name: Optional[str] = None
     teacher_name: Optional[str] = None
     course_name: Optional[str] = None
     student_contract_no: Optional[str] = None
@@ -155,6 +157,8 @@ class BookingResponse(BaseModel):
                 "created_at": "2026-04-10T08:00:00",
                 "updated_at": "2026-04-10T08:00:00",
                 "student_name": "王小明",
+                "student_no": "EOPS001",
+                "student_eng_name": "Ming Wang",
                 "teacher_name": "陳美玲",
                 "course_name": "英語日常會話",
                 "student_contract_no": "SC-2026-001",

--- a/backend/app/schemas/student.py
+++ b/backend/app/schemas/student.py
@@ -2,6 +2,8 @@ from pydantic import BaseModel, EmailStr, Field
 from typing import Optional
 from datetime import datetime, date
 
+from app.schemas._validators import OptionalDate
+
 
 class StudentCreate(BaseModel):
     """建立學生"""
@@ -11,7 +13,7 @@ class StudentCreate(BaseModel):
     email: EmailStr = Field(..., description="Email")
     phone: str = Field(..., min_length=1, max_length=20, description="電話（必填）")
     address: Optional[str] = Field(None, description="地址")
-    birth_date: Optional[date] = Field(None, description="生日")
+    birth_date: OptionalDate = Field(None, description="生日（空字串自動轉 None）")
     id_number: Optional[str] = Field(None, max_length=20, description="身分證字號")
     student_type: str = Field("formal", description="學生類型 (formal/trial)")
     is_active: bool = Field(True, description="是否啟用")
@@ -38,7 +40,7 @@ class StudentUpdate(BaseModel):
     email: Optional[EmailStr] = None
     phone: Optional[str] = Field(None, max_length=20)
     address: Optional[str] = None
-    birth_date: Optional[date] = None
+    birth_date: OptionalDate = None
     id_number: Optional[str] = Field(None, max_length=20)
     student_type: Optional[str] = Field(None, description="學生類型 (formal/trial)")
     is_active: Optional[bool] = None

--- a/backend/app/schemas/student.py
+++ b/backend/app/schemas/student.py
@@ -114,24 +114,20 @@ class StudentListResponse(BaseModel):
 # ========== 試上轉正 ==========
 
 class ConvertToFormalRequest(BaseModel):
-    """試上轉正請求"""
-    contract_no: str = Field(..., description="合約編號")
-    total_lessons: int = Field(..., ge=1, description="總堂數")
-    total_amount: float = Field(..., ge=0, description="合約總金額")
-    start_date: date = Field(..., description="合約開始日期")
-    end_date: date = Field(..., description="合約結束日期")
+    """試上轉正請求
+
+    新流程：必須先建立 pending 合約並上傳 PDF，轉正只負責 activate。
+    """
+    student_contract_id: str = Field(..., description="待確認合約 ID（contract_status=pending 且已上傳 PDF）")
     teacher_id: Optional[str] = Field(None, description="指定教師 ID（計算轉正獎金）")
     booking_id: Optional[str] = Field(None, description="關聯的試上預約 ID")
-    notes: Optional[str] = Field(None, description="備註")
 
     model_config = {
         "json_schema_extra": {
             "examples": [{
-                "contract_no": "SC-2026-001",
-                "total_lessons": 24,
-                "total_amount": 36000.0,
-                "start_date": "2026-02-01",
-                "end_date": "2026-07-31",
+                "student_contract_id": "660e8400-e29b-41d4-a716-446655440000",
+                "teacher_id": "770e8400-e29b-41d4-a716-446655440000",
+                "booking_id": "880e8400-e29b-41d4-a716-446655440000",
             }]
         }
     }
@@ -177,6 +173,7 @@ class ConvertToFormalResponse(BaseModel):
     contract: ConvertToFormalContractInfo
     bonus_recorded: bool = False
     bonus_amount: Optional[float] = None
+    bonus_error: Optional[str] = None  # 獎金處理失敗訊息（已記到 system_alerts）
 
     model_config = {
         "json_schema_extra": {

--- a/backend/app/schemas/student_contract.py
+++ b/backend/app/schemas/student_contract.py
@@ -208,6 +208,7 @@ class StudentContractResponse(BaseModel):
     used_leave_count: int = 0
     used_emergency_leave_count: int = 0
     emergency_leave_quota: Optional[int] = None  # enrich 計算: ceil(total_lessons * 0.2)
+    remaining_emergency_leave_count: Optional[int] = None  # enrich 計算: max(0, quota - used)
     is_recurring: bool = False
     notes: Optional[str] = None
     created_at: Optional[datetime] = None

--- a/backend/app/schemas/teacher_slot.py
+++ b/backend/app/schemas/teacher_slot.py
@@ -199,6 +199,7 @@ class TeacherSlotResponse(BaseModel):
     end_time: time
     is_available: bool
     is_booked: bool
+    booking_count: int = 0
     notes: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -219,6 +220,7 @@ class TeacherSlotResponse(BaseModel):
                 "end_time": "12:00:00",
                 "is_available": True,
                 "is_booked": False,
+                "booking_count": 0,
                 "notes": None,
                 "created_at": "2026-04-01T08:00:00",
                 "updated_at": "2026-04-01T08:00:00",

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -66,6 +66,8 @@ class AuthService:
         
         # 2. 取得用戶身份資訊 (從 user_profiles 表)
         identity = await self._get_user_identity(user.id)
+        if not identity.get("is_active", True):
+            raise AuthException("帳號已停用，請聯絡管理員")
         user_role = identity["role_key"]
         role_id = identity["role_id"]
         profile_extra = await self.get_profile_extra(user.id)
@@ -260,6 +262,8 @@ class AuthService:
         """
         # 取得用戶身份資訊
         identity = await self._get_user_identity(user_id)
+        if not identity.get("is_active", True):
+            raise AuthException("帳號已停用，請聯絡管理員")
         user_role = identity["role_key"]
         role_id = identity["role_id"]
 
@@ -334,7 +338,8 @@ class AuthService:
             rows = await self.supabase.pool.fetch(
                 """
                 SELECT r.key AS role_key, r.id AS role_id,
-                       up.student_id, up.teacher_id, up.employee_id
+                       up.student_id, up.teacher_id, up.employee_id,
+                       up.is_active
                 FROM user_profiles up
                 JOIN roles r ON r.id = up.role_id
                 WHERE up.id = $1
@@ -349,11 +354,12 @@ class AuthService:
                     "student_id": str(row["student_id"]) if row["student_id"] else None,
                     "teacher_id": str(row["teacher_id"]) if row["teacher_id"] else None,
                     "employee_id": str(row["employee_id"]) if row["employee_id"] else None,
+                    "is_active": bool(row["is_active"]) if row["is_active"] is not None else True,
                 }
         except:
             pass
 
-        return {"role_key": "student", "role_id": None, "student_id": None, "teacher_id": None, "employee_id": None}
+        return {"role_key": "student", "role_id": None, "student_id": None, "teacher_id": None, "employee_id": None, "is_active": True}
 
     async def get_profile_extra(self, user_id: str) -> dict:
         """從資料庫取得用戶 profile 額外資訊（must_change_password, entity IDs, role_id 等）"""

--- a/backend/tests/e2e/live_e2e_leave_flow_test.py
+++ b/backend/tests/e2e/live_e2e_leave_flow_test.py
@@ -173,6 +173,7 @@ class LeaveFlowTester:
             await self._test("列表包含 leave_type / deduct_lesson", self._verify_list)
             await self._test("單筆查詢欄位正確", self._verify_single)
             await self._test("合約 emergency_leave_quota 正確", self._verify_contract_quota)
+            await self._test("補償堂數計入 emergency_leave_quota", self._verify_quota_with_compensation)
 
             # Cleanup
             print(f"\n  Cleanup")
@@ -426,6 +427,63 @@ class LeaveFlowTester:
             return f"quota={data.get('emergency_leave_quota')}, expected 1 (ceil(5*0.2))"
         if data.get("used_emergency_leave_count") != 1:
             return f"used={data.get('used_emergency_leave_count')}, expected 1"
+        if data.get("remaining_emergency_leave_count") != 0:
+            return f"remaining_em={data.get('remaining_emergency_leave_count')}, expected 0"
+        return True
+
+    async def _verify_quota_with_compensation(self):
+        """補償堂數應計入 emergency_leave_quota = ceil((total_lessons + 補償) * 0.2)"""
+        sc_id = self.student_contract_id
+        # baseline: total_lessons=5, used_em=1, quota=1, remaining=0
+
+        # +compensation 10 → effective=15, quota=ceil(15*0.2)=3, remaining=max(0,3-1)=2
+        r = await self._post(f"/api/v1/student-contracts/{sc_id}/details", {
+            "detail_type": "compensation", "description": f"{TEST_PREFIX}comp1", "amount": 10,
+        })
+        if r.status_code != 200:
+            return f"add comp1: {r.status_code} {r.text[:200]}"
+        comp1_id = r.json()["data"]["id"]
+
+        r = await self._get(f"/api/v1/student-contracts/{sc_id}")
+        d = r.json()["data"]
+        if d.get("emergency_leave_quota") != 3:
+            return f"+10: quota={d.get('emergency_leave_quota')}, expected 3"
+        if d.get("remaining_emergency_leave_count") != 2:
+            return f"+10: remaining_em={d.get('remaining_emergency_leave_count')}, expected 2"
+
+        # +compensation 5 → effective=20, quota=4, remaining=3
+        r = await self._post(f"/api/v1/student-contracts/{sc_id}/details", {
+            "detail_type": "compensation", "description": f"{TEST_PREFIX}comp2", "amount": 5,
+        })
+        if r.status_code != 200:
+            return f"add comp2: {r.status_code}"
+        comp2_id = r.json()["data"]["id"]
+
+        r = await self._get(f"/api/v1/student-contracts/{sc_id}")
+        d = r.json()["data"]
+        if d.get("emergency_leave_quota") != 4:
+            return f"+15: quota={d.get('emergency_leave_quota')}, expected 4"
+        if d.get("remaining_emergency_leave_count") != 3:
+            return f"+15: remaining_em={d.get('remaining_emergency_leave_count')}, expected 3"
+
+        # list endpoint 也應反映
+        r = await self._get("/api/v1/student-contracts", params={"student_id": self.student_id})
+        items = r.json().get("data", [])
+        match = [x for x in items if x["id"] == sc_id]
+        if not match:
+            return "contract missing in list"
+        if match[0].get("emergency_leave_quota") != 4:
+            return f"list: quota={match[0].get('emergency_leave_quota')}, expected 4"
+        if match[0].get("remaining_emergency_leave_count") != 3:
+            return f"list: remaining_em={match[0].get('remaining_emergency_leave_count')}, expected 3"
+
+        # 刪除補償 → quota 還原 (cleanup 也會兜底，這裡先驗證刪除路徑)
+        await self.client.delete(f"{self.url}/api/v1/student-contracts/{sc_id}/details/{comp1_id}")
+        await self.client.delete(f"{self.url}/api/v1/student-contracts/{sc_id}/details/{comp2_id}")
+        r = await self._get(f"/api/v1/student-contracts/{sc_id}")
+        d = r.json()["data"]
+        if d.get("emergency_leave_quota") != 1:
+            return f"after delete: quota={d.get('emergency_leave_quota')}, expected 1"
         return True
 
     # ── Cleanup ──
@@ -436,6 +494,7 @@ class LeaveFlowTester:
         sqls = [
             f"DELETE FROM leave_records WHERE booking_id IN ({bk_sub})",
             f"DELETE FROM student_contract_leave_records WHERE student_contract_id IN ({sc_sub})",
+            f"DELETE FROM student_contract_details WHERE student_contract_id IN ({sc_sub})",
             f"DELETE FROM substitute_details WHERE booking_id IN ({bk_sub})",
             f"DELETE FROM booking_details WHERE booking_id IN ({bk_sub})",
             f"DELETE FROM zoom_meeting_logs WHERE booking_id IN ({bk_sub})",

--- a/backend/tests/e2e/live_e2e_trial_to_formal_test.py
+++ b/backend/tests/e2e/live_e2e_trial_to_formal_test.py
@@ -93,6 +93,11 @@ class TrialToFormalTester:
         self.pending_booking_id = None     # trial + pending (should reject)
         self.trial_booking_2_id = None     # trial + completed for student 2
 
+        # 新流程：必須預先有 pending 合約並上傳 PDF
+        self.contract_1_id = None          # pending, student_1, with PDF
+        self.contract_2_id = None          # pending, student_2, with PDF
+        self.contract_no_pdf_id = None     # pending, student_2, no PDF (錯誤測試)
+
         self.original_completed_bonus = None
         self.original_formal_bonus = None
 
@@ -155,11 +160,14 @@ class TrialToFormalTester:
             print("  " + "-" * 40)
             await self._test("拒絕 regular booking（400）", self._reject_regular)
             await self._test("拒絕 pending booking（400）", self._reject_pending)
+            await self._test("拒絕沒上傳 PDF 的合約（400）", self._reject_no_pdf)
+            await self._test("拒絕合約不屬於該學生（400）", self._reject_wrong_student)
 
             # Phase 3: 試上轉正 → 差額獎金
             print(f"\n  Phase 3: 試上轉正")
             print("  " + "-" * 40)
             await self._test("轉正學生 1（成功）", self._convert_student_1)
+            await self._test("驗證合約狀態 → active", self._verify_contract_active)
             await self._test("驗證 trial_to_formal 差額獎金", self._verify_diff_bonus)
             await self._test("驗證總獎金 = trial_to_formal_bonus", self._verify_total_bonus)
             await self._test("驗證 bookings_view.is_trial_to_formal", self._verify_is_trial_to_formal)
@@ -263,6 +271,29 @@ class TrialToFormalTester:
 
         if not all([self.trial_booking_id, self.regular_booking_id, self.pending_booking_id, self.trial_booking_2_id]):
             return "Failed to create some bookings"
+
+        # 預建 pending 合約（新流程要求）
+        start = date.today().isoformat()
+        end = (date.today() + timedelta(days=180)).isoformat()
+
+        def _sc(no, sid, with_pdf=True):
+            file_clause = (
+                f"'student-contracts/seed/{no}.pdf'" if with_pdf else "NULL"
+            )
+            return db_value(
+                f"INSERT INTO student_contracts "
+                f"(contract_no, student_id, contract_status, start_date, end_date, "
+                f" total_lessons, remaining_lessons, total_amount, total_leave_allowed, "
+                f" contract_file_path, notes) "
+                f"VALUES ('{no}', '{sid}', 'pending', '{start}', '{end}', "
+                f"10, 10, 10000, 2, {file_clause}, '{TEST_PREFIX}') RETURNING id"
+            )
+
+        self.contract_1_id = _sc(f"{TEST_PREFIX}C1", self.student_1_id, with_pdf=True)
+        self.contract_2_id = _sc(f"{TEST_PREFIX}C2", self.student_2_id, with_pdf=True)
+        self.contract_no_pdf_id = _sc(f"{TEST_PREFIX}CNOPDF", self.student_2_id, with_pdf=False)
+        if not all([self.contract_1_id, self.contract_2_id, self.contract_no_pdf_id]):
+            return "Failed to create pending contracts"
         return True
 
     # ── Phase 1: 試上完成 ──
@@ -303,22 +334,17 @@ class TrialToFormalTester:
 
     # ── Phase 2: 轉正 ──
 
-    def _convert_payload(self, booking_id, suffix="C001"):
+    def _convert_payload(self, contract_id, booking_id=None):
         return {
-            "contract_no": f"{TEST_PREFIX}{suffix}",
-            "total_lessons": 10,
-            "total_amount": 10000,
-            "start_date": date.today().isoformat(),
-            "end_date": (date.today() + timedelta(days=180)).isoformat(),
+            "student_contract_id": contract_id,
             "teacher_id": self.teacher_id,
             "booking_id": booking_id,
-            "notes": TEST_PREFIX,
         }
 
     async def _convert_student_1(self):
         resp = await self._post(
             f"/api/v1/students/{self.student_1_id}/convert-to-formal",
-            self._convert_payload(self.trial_booking_id),
+            self._convert_payload(self.contract_1_id, self.trial_booking_id),
         )
         if resp.status_code != 200:
             return f"{resp.status_code} {resp.text[:200]}"
@@ -327,6 +353,16 @@ class TrialToFormalTester:
             return f"student_type not formal"
         if data.get("bonus_amount") != EXPECTED_DIFF_BONUS:
             return f"bonus_amount={data.get('bonus_amount')}, expected {EXPECTED_DIFF_BONUS}"
+        return True
+
+    async def _verify_contract_active(self):
+        rows = db_query(
+            f"SELECT contract_status FROM student_contracts WHERE id = '{self.contract_1_id}'"
+        )
+        if not rows:
+            return "contract not found"
+        if rows[0]["contract_status"] != "active":
+            return f"contract_status={rows[0]['contract_status']}, expected active"
         return True
 
     async def _verify_diff_bonus(self):
@@ -375,7 +411,7 @@ class TrialToFormalTester:
     async def _reject_regular(self):
         resp = await self._post(
             f"/api/v1/students/{self.student_1_id}/convert-to-formal",
-            self._convert_payload(self.regular_booking_id, "ERR1"),
+            self._convert_payload(self.contract_1_id, self.regular_booking_id),
         )
         if resp.status_code != 400:
             return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
@@ -387,7 +423,7 @@ class TrialToFormalTester:
     async def _reject_pending(self):
         resp = await self._post(
             f"/api/v1/students/{self.student_1_id}/convert-to-formal",
-            self._convert_payload(self.pending_booking_id, "ERR2"),
+            self._convert_payload(self.contract_1_id, self.pending_booking_id),
         )
         if resp.status_code != 400:
             return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
@@ -396,10 +432,36 @@ class TrialToFormalTester:
             return f"wrong message: {msg}"
         return True
 
-    async def _reject_already_converted(self):
+    async def _reject_no_pdf(self):
         resp = await self._post(
             f"/api/v1/students/{self.student_2_id}/convert-to-formal",
-            self._convert_payload(self.trial_booking_id, "ERR3"),
+            self._convert_payload(self.contract_no_pdf_id),
+        )
+        if resp.status_code != 400:
+            return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+        msg = self._err_msg(resp)
+        if "PDF" not in msg:
+            return f"wrong message: {msg}"
+        return True
+
+    async def _reject_wrong_student(self):
+        # student_2 拿 student_1 的 contract_1_id
+        resp = await self._post(
+            f"/api/v1/students/{self.student_2_id}/convert-to-formal",
+            self._convert_payload(self.contract_1_id),
+        )
+        if resp.status_code != 400:
+            return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+        msg = self._err_msg(resp)
+        if "不屬於" not in msg:
+            return f"wrong message: {msg}"
+        return True
+
+    async def _reject_already_converted(self):
+        # student_2 + 已被 student_1 標記轉正的 trial_booking_id
+        resp = await self._post(
+            f"/api/v1/students/{self.student_2_id}/convert-to-formal",
+            self._convert_payload(self.contract_2_id, self.trial_booking_id),
         )
         if resp.status_code != 400:
             return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
@@ -418,7 +480,7 @@ class TrialToFormalTester:
         )
         resp = await self._post(
             f"/api/v1/students/{self.student_2_id}/convert-to-formal",
-            self._convert_payload(self.trial_booking_2_id, "C002"),
+            self._convert_payload(self.contract_2_id, self.trial_booking_2_id),
         )
         if resp.status_code != 200:
             return f"{resp.status_code} {resp.text[:200]}"
@@ -452,6 +514,8 @@ class TrialToFormalTester:
 
     async def _cleanup(self):
         sqls = [
+            f"DELETE FROM system_alerts WHERE alert_type = 'trial_to_formal_bonus_failed' "
+            f"AND metadata->>'student_id' IN (SELECT id::text FROM students WHERE student_no LIKE '{TEST_PREFIX}%')",
             f"DELETE FROM teacher_bonus_records WHERE "
             f"related_student_id IN (SELECT id FROM students WHERE student_no LIKE '{TEST_PREFIX}%') "
             f"OR description LIKE '%{TEST_PREFIX}%'",

--- a/backend/tests/e2e/live_e2e_trial_to_formal_test.py
+++ b/backend/tests/e2e/live_e2e_trial_to_formal_test.py
@@ -162,6 +162,8 @@ class TrialToFormalTester:
             await self._test("拒絕 pending booking（400）", self._reject_pending)
             await self._test("拒絕沒上傳 PDF 的合約（400）", self._reject_no_pdf)
             await self._test("拒絕合約不屬於該學生（400）", self._reject_wrong_student)
+            await self._test("拒絕為試上學生建 active 合約（400）", self._reject_create_active_for_trial)
+            await self._test("拒絕 PUT 把試上學生合約改 active（400）", self._reject_update_to_active_for_trial)
 
             # Phase 3: 試上轉正 → 差額獎金
             print(f"\n  Phase 3: 試上轉正")
@@ -454,6 +456,36 @@ class TrialToFormalTester:
             return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
         msg = self._err_msg(resp)
         if "不屬於" not in msg:
+            return f"wrong message: {msg}"
+        return True
+
+    async def _reject_create_active_for_trial(self):
+        # 直接用 API POST 建 active 合約給 trial 學生 → 應拒
+        resp = await self._post("/api/v1/student-contracts", {
+            "student_id": self.student_2_id,
+            "contract_status": "active",
+            "start_date": date.today().isoformat(),
+            "end_date": (date.today() + timedelta(days=180)).isoformat(),
+            "total_lessons": 10, "remaining_lessons": 10, "total_amount": 10000,
+            "notes": TEST_PREFIX,
+        })
+        if resp.status_code != 400:
+            return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+        msg = self._err_msg(resp)
+        if "轉正" not in msg:
+            return f"wrong message: {msg}"
+        return True
+
+    async def _reject_update_to_active_for_trial(self):
+        # PUT 把 contract_2_id (pending, trial) 改 active → 應拒
+        resp = await self._put(
+            f"/api/v1/student-contracts/{self.contract_2_id}",
+            {"contract_status": "active"},
+        )
+        if resp.status_code != 400:
+            return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+        msg = self._err_msg(resp)
+        if "轉正" not in msg:
             return f"wrong message: {msg}"
         return True
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
       # 覆寫：需用 container 內部 hostname
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       REDIS_URL: redis://:${REDIS_PASSWORD:-changeme}@redis:6379/0
+      # Container TZ：DB 業務欄位 (booking_date / start_time / end_time …) 都是
+      # Asia/Taipei 本地時間語意；backend 的 datetime.now() 必須對齊，否則
+      # auto_end_overdue_meetings 等比較會晚 8 小時。
+      TZ: Asia/Taipei
     ports:
       - ${BACKEND_PORT:-8001}:8000
     restart: unless-stopped
@@ -143,29 +147,30 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     restart: "no"
 
-  # pgadmin:
-  #   container_name: teaching-platform-pgadmin
-  #   image: dpage/pgadmin4:9.12.0
-  #   depends_on:
-  #     db:
-  #       condition: service_healthy
-  #   environment:
-  #     PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@local.dev}
-  #     PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
-  #     PGADMIN_CONFIG_SERVER_MODE: "True"
-  #     PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "True"
-  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-  #   volumes:
-  #     - ./pgadmin/servers.json:/pgadmin4/servers.json:ro
-  #     - pgadmin-data:/var/lib/pgadmin
-  #   entrypoint: >
-  #     /bin/sh -c "
-  #     echo \"db:5432:*:postgres:$$POSTGRES_PASSWORD\" > /tmp/pgpass &&
-  #     chmod 600 /tmp/pgpass &&
-  #     /entrypoint.sh
-  #     "
-  #   ports:
-  #     - ${PGADMIN_PORT:-5050}:80
+  pgadmin:
+    container_name: teaching-platform-pgadmin
+    image: dpage/pgadmin4:9.12.0
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@local.dev}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
+      PGADMIN_CONFIG_SERVER_MODE: "True"
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "True"
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ./pgadmin/servers.json:/pgadmin4/servers.json:ro
+      - pgadmin-data:/var/lib/pgadmin
+    entrypoint: >
+      /bin/sh -c "
+      echo \"db:5432:*:postgres:$$POSTGRES_PASSWORD\" > /tmp/pgpass &&
+      chmod 600 /tmp/pgpass &&
+      /entrypoint.sh
+      "
+    ports:
+      - ${PGADMIN_PORT:-5050}:80
+    restart: unless-stopped
 
 volumes:
   db-data:

--- a/frontend-dennis/src/app/students/page.tsx
+++ b/frontend-dennis/src/app/students/page.tsx
@@ -6,6 +6,7 @@ import { studentsApi, Student, CreateStudentData, UpdateStudentData, ConvertToFo
 import { Booking } from '@/lib/api/bookings'
 import { studentTeacherPreferencesApi, StudentTeacherPreference, CreatePreferenceData, AllowedTeacher } from '@/lib/api/studentTeacherPreferences'
 import { bookingsApi, CourseOption } from '@/lib/api/bookings'
+import { studentContractsApi, StudentContract } from '@/lib/api/studentContracts'
 import { invitesApi } from '@/lib/api/invites'
 import { Plus, Pencil, Trash2, Search, X, GraduationCap, CheckCircle, XCircle, Mail, Phone, Star, Settings, ArrowLeft, Link, Copy, Check, UserPlus, ArrowUpCircle, Eye } from 'lucide-react'
 import NextLink from 'next/link'
@@ -68,13 +69,14 @@ export default function StudentsPage() {
     // 試上轉正
     const [convertStudent, setConvertStudent] = useState<Student | null>(null)
     const [convertFormData, setConvertFormData] = useState<ConvertToFormalData>({
-        contract_no: '', total_lessons: 1, total_amount: 0,
-        start_date: '', end_date: '',
+        student_contract_id: '',
     })
     const [convertError, setConvertError] = useState<string | null>(null)
     const [convertSubmitting, setConvertSubmitting] = useState(false)
     const [convertBookings, setConvertBookings] = useState<Booking[]>([])
     const [convertBookingsLoading, setConvertBookingsLoading] = useState(false)
+    const [convertContracts, setConvertContracts] = useState<StudentContract[]>([])
+    const [convertContractsLoading, setConvertContractsLoading] = useState(false)
 
     const isStaff = profile?.employee_id != null
 
@@ -299,18 +301,28 @@ export default function StudentsPage() {
     // === 試上轉正 ===
     const openConvertModal = async (student: Student) => {
         setConvertStudent(student)
-        setConvertFormData({
-            contract_no: '', total_lessons: 1, total_amount: 0,
-            start_date: '', end_date: '',
-        })
+        setConvertFormData({ student_contract_id: '' })
         setConvertError(null)
         setConvertBookings([])
+        setConvertContracts([])
         setConvertBookingsLoading(true)
+        setConvertContractsLoading(true)
         try {
-            const { data } = await bookingsApi.list({ student_id: student.id, per_page: 100 })
-            if (data) setConvertBookings(data.data)
+            const [bookingsRes, contractsRes] = await Promise.all([
+                bookingsApi.list({ student_id: student.id, per_page: 100 }),
+                studentContractsApi.list({ student_id: student.id, contract_status: 'pending', per_page: 100 }),
+            ])
+            if (bookingsRes.data) setConvertBookings(bookingsRes.data.data)
+            if (contractsRes.data) {
+                setConvertContracts(contractsRes.data.data)
+                // 只有一筆 pending 合約 → 自動預選
+                if (contractsRes.data.data.length === 1) {
+                    setConvertFormData(prev => ({ ...prev, student_contract_id: contractsRes.data!.data[0].id }))
+                }
+            }
         } catch {}
         setConvertBookingsLoading(false)
+        setConvertContractsLoading(false)
     }
 
     const handleConvert = async (e: React.FormEvent) => {
@@ -323,11 +335,18 @@ export default function StudentsPage() {
         if (error) {
             setConvertError(error.message)
         } else {
+            if (data?.bonus_error) {
+                // 轉正成功但獎金處理失敗 → 提示 + 關閉 modal
+                alert(`轉正成功，但獎金處理失敗：${data.bonus_error}（已記錄於系統告警）`)
+            }
             setConvertStudent(null)
             fetchStudents()
         }
         setConvertSubmitting(false)
     }
+
+    const selectedConvertContract = convertContracts.find(c => c.id === convertFormData.student_contract_id)
+    const canSubmitConvert = !!selectedConvertContract && !!selectedConvertContract.contract_file_path
 
     // === 邀請連結 ===
     const handleGenerateInvite = async (student: Student) => {
@@ -898,41 +917,36 @@ export default function StudentsPage() {
 
                                 <form onSubmit={handleConvert} className="space-y-4">
                                     <div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-1">合約編號 <span className="text-red-500">*</span></label>
-                                        <input type="text" value={convertFormData.contract_no}
-                                            onChange={(e) => setConvertFormData({ ...convertFormData, contract_no: e.target.value })}
-                                            className="input-field" placeholder="例如：SC20260303001" required />
-                                    </div>
-                                    <div className="grid grid-cols-2 gap-4">
-                                        <div>
-                                            <label className="block text-sm font-medium text-gray-700 mb-1">總堂數 <span className="text-red-500">*</span></label>
-                                            <input type="number" min={1} value={convertFormData.total_lessons}
-                                                onChange={(e) => setConvertFormData({ ...convertFormData, total_lessons: parseInt(e.target.value) || 1 })}
-                                                className="input-field" required />
-                                        </div>
-                                        <div>
-                                            <label className="block text-sm font-medium text-gray-700 mb-1">合約總金額 <span className="text-red-500">*</span></label>
-                                            <input type="number" min={0} step={1} value={convertFormData.total_amount}
-                                                onChange={(e) => setConvertFormData({ ...convertFormData, total_amount: parseFloat(e.target.value) || 0 })}
-                                                className="input-field" required />
-                                        </div>
-                                    </div>
-                                    <div className="grid grid-cols-2 gap-4">
-                                        <div>
-                                            <label className="block text-sm font-medium text-gray-700 mb-1">開始日期 <span className="text-red-500">*</span></label>
-                                            <input type="date" value={convertFormData.start_date}
-                                                onChange={(e) => setConvertFormData({ ...convertFormData, start_date: e.target.value })}
-                                                className="input-field" required />
-                                        </div>
-                                        <div>
-                                            <label className="block text-sm font-medium text-gray-700 mb-1">結束日期 <span className="text-red-500">*</span></label>
-                                            <input type="date" value={convertFormData.end_date}
-                                                onChange={(e) => setConvertFormData({ ...convertFormData, end_date: e.target.value })}
-                                                className="input-field" required />
-                                        </div>
+                                        <label className="block text-sm font-medium text-gray-700 mb-1">待確認合約 <span className="text-red-500">*</span></label>
+                                        {convertContractsLoading ? (
+                                            <div className="text-sm text-gray-400">載入合約中...</div>
+                                        ) : convertContracts.length > 0 ? (
+                                            <select
+                                                value={convertFormData.student_contract_id}
+                                                onChange={(e) => setConvertFormData({ ...convertFormData, student_contract_id: e.target.value })}
+                                                className="input-field" required
+                                            >
+                                                <option value="">請選擇</option>
+                                                {convertContracts.map(c => (
+                                                    <option key={c.id} value={c.id}>
+                                                        {c.contract_no}（{c.start_date} ~ {c.end_date}, {c.total_lessons} 堂）
+                                                        {!c.contract_file_path ? ' — 未上傳 PDF' : ''}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                        ) : (
+                                            <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg text-amber-800 text-sm">
+                                                尚無 pending 合約，請先到「學生合約」頁建立一筆 pending 合約並上傳 PDF。
+                                            </div>
+                                        )}
+                                        {selectedConvertContract && !selectedConvertContract.contract_file_path && (
+                                            <div className="mt-2 text-sm text-red-600">
+                                                此合約尚未上傳 PDF，無法轉正。請先於合約頁完成 PDF 上傳。
+                                            </div>
+                                        )}
                                     </div>
                                     <div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-1">關聯試上預約（選填）</label>
+                                        <label className="block text-sm font-medium text-gray-700 mb-1">關聯試上預約（選填，計算獎金、標記轉正）</label>
                                         {convertBookingsLoading ? (
                                             <div className="text-sm text-gray-400">載入預約中...</div>
                                         ) : convertBookings.length > 0 ? (
@@ -973,15 +987,9 @@ export default function StudentsPage() {
                                             ))}
                                         </select>
                                     </div>
-                                    <div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-1">備註</label>
-                                        <textarea value={convertFormData.notes || ''}
-                                            onChange={(e) => setConvertFormData({ ...convertFormData, notes: e.target.value || undefined })}
-                                            className="input-field" rows={2} />
-                                    </div>
                                     <div className="flex gap-3 pt-4">
                                         <button type="button" onClick={() => setConvertStudent(null)} className="btn-secondary flex-1" disabled={convertSubmitting}>取消</button>
-                                        <button type="submit" className="btn-primary flex-1" disabled={convertSubmitting}>
+                                        <button type="submit" className="btn-primary flex-1" disabled={convertSubmitting || !canSubmitConvert}>
                                             {convertSubmitting ? <span className="flex items-center justify-center"><div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>處理中...</span> : '確認轉正'}
                                         </button>
                                     </div>

--- a/frontend-dennis/src/app/teacher-slots/page.tsx
+++ b/frontend-dennis/src/app/teacher-slots/page.tsx
@@ -847,6 +847,10 @@ export default function TeacherSlotsPage() {
                                                             <AlertCircle className="w-3 h-3 mr-1" />
                                                             預約已滿
                                                         </span>
+                                                    ) : (slot.booking_count ?? 0) > 0 ? (
+                                                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
+                                                            已預約 {slot.booking_count} 堂
+                                                        </span>
                                                     ) : (
                                                         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
                                                             尚有空位

--- a/frontend-dennis/src/lib/api/bookings.ts
+++ b/frontend-dennis/src/lib/api/bookings.ts
@@ -29,6 +29,8 @@ export interface Booking {
     updated_at?: string
     // 關聯資料
     student_name?: string
+    student_no?: string
+    student_eng_name?: string
     teacher_name?: string
     course_name?: string
     student_contract_no?: string

--- a/frontend-dennis/src/lib/api/students.ts
+++ b/frontend-dennis/src/lib/api/students.ts
@@ -104,14 +104,9 @@ export interface UpdateStudentData {
 }
 
 export interface ConvertToFormalData {
-    contract_no: string
-    total_lessons: number
-    total_amount: number
-    start_date: string
-    end_date: string
+    student_contract_id: string
     teacher_id?: string
     booking_id?: string
-    notes?: string
 }
 
 export interface ConvertToFormalResponse {
@@ -132,6 +127,7 @@ export interface ConvertToFormalResponse {
     }
     bonus_recorded: boolean
     bonus_amount?: number
+    bonus_error?: string
 }
 
 export const studentsApi = {

--- a/frontend-dennis/src/lib/api/teacherSlots.ts
+++ b/frontend-dennis/src/lib/api/teacherSlots.ts
@@ -9,6 +9,7 @@ export interface TeacherSlot {
     end_time: string
     is_available: boolean
     is_booked: boolean
+    booking_count?: number
     notes?: string
     created_at?: string
     updated_at?: string

--- a/scripts/db-purge-students-teachers.sh
+++ b/scripts/db-purge-students-teachers.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# 硬刪除所有學生、老師、預約與相關資料 (本機 docker DB 專用)
+#
+# 保留：employees、employee 對應的 users / user_profiles、courses、roles、
+#       page_permissions、google_drive_config、zoom_accounts、_migrations 等
+#       與 teacher/student/booking 無關的資料。
+#
+# 使用方式：
+#   ./scripts/db-purge-students-teachers.sh                       # 互動式確認
+#   ./scripts/db-purge-students-teachers.sh --yes                 # 跳過確認 (CI/cron 用)
+#   ./scripts/db-purge-students-teachers.sh --dry-run             # 只顯示會刪幾筆，不實際刪
+#   CONTAINER=teaching-platform-db ./scripts/db-purge-students-teachers.sh   # 自訂 container 名
+#
+# ⚠️ 動作不可逆。預設拒絕在非本機環境跑：
+#    - 必須能 docker exec 到 ${CONTAINER}
+#    - DATABASE_URL host 必須是 'db' 或 'localhost'
+#    - 若想跑遠端，自行 export ALLOW_REMOTE=1 並對自己風險負責
+
+set -euo pipefail
+
+CONTAINER="${CONTAINER:-teaching-platform-db}"
+PG_USER="${PG_USER:-postgres}"
+PG_DB="${PG_DB:-postgres}"
+
+DRY_RUN=0
+ASSUME_YES=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --yes|-y) ASSUME_YES=1 ;;
+        -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
+# Safety: 拒絕在 production 風格的 container 名稱跑
+if [[ "$CONTAINER" != *"local"* && "$CONTAINER" != *"teaching-platform"* && "${ALLOW_REMOTE:-0}" != "1" ]]; then
+    echo "[abort] CONTAINER='$CONTAINER' 不像本機 docker，請設 ALLOW_REMOTE=1 自行確認再跑" >&2
+    exit 3
+fi
+
+if ! docker exec "$CONTAINER" true >/dev/null 2>&1; then
+    echo "[abort] 連不到 container '$CONTAINER'" >&2
+    exit 4
+fi
+
+psql() {
+    docker exec -i "$CONTAINER" psql -U "$PG_USER" -d "$PG_DB" "$@"
+}
+
+# ─── 1. 預覽：列出將被影響的筆數 ───
+echo "==> 影響範圍（執行前）"
+psql -At <<'SQL' | column -t -s '|'
+SELECT 'teachers' AS tbl, count(*) FROM teachers
+UNION ALL SELECT 'students',                count(*) FROM students
+UNION ALL SELECT 'bookings',                count(*) FROM bookings
+UNION ALL SELECT 'zoom_meeting_logs',       count(*) FROM zoom_meeting_logs
+UNION ALL SELECT 'teacher_bonus_records',   count(*) FROM teacher_bonus_records
+UNION ALL SELECT 'substitute_details',      count(*) FROM substitute_details
+UNION ALL SELECT 'leave_records',           count(*) FROM leave_records
+UNION ALL SELECT 'booking_details',         count(*) FROM booking_details
+UNION ALL SELECT 'teacher_available_slots', count(*) FROM teacher_available_slots
+UNION ALL SELECT 'teacher_work_schedules',  count(*) FROM teacher_work_schedules
+UNION ALL SELECT 'teacher_contracts',       count(*) FROM teacher_contracts
+UNION ALL SELECT 'teacher_contract_details',count(*) FROM teacher_contract_details
+UNION ALL SELECT 'teacher_zoom_accounts',   count(*) FROM teacher_zoom_accounts
+UNION ALL SELECT 'teacher_details',         count(*) FROM teacher_details
+UNION ALL SELECT 'student_contracts',       count(*) FROM student_contracts
+UNION ALL SELECT 'student_contract_details',count(*) FROM student_contract_details
+UNION ALL SELECT 'student_courses',         count(*) FROM student_courses
+UNION ALL SELECT 'student_teacher_preferences', count(*) FROM student_teacher_preferences
+UNION ALL SELECT 'student_details',         count(*) FROM student_details
+UNION ALL SELECT 'user_profiles (teacher/student)', count(*)
+                FROM user_profiles WHERE teacher_id IS NOT NULL OR student_id IS NOT NULL
+UNION ALL SELECT 'users (linked)',          count(*)
+                FROM users u
+                JOIN user_profiles up ON up.id = u.id
+                WHERE up.teacher_id IS NOT NULL OR up.student_id IS NOT NULL
+ORDER BY tbl;
+SQL
+echo
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[dry-run] 結束，未實際刪除"
+    exit 0
+fi
+
+# ─── 2. 互動確認 ───
+if [[ "$ASSUME_YES" != "1" ]]; then
+    echo "⚠️  以上資料即將從 container '$CONTAINER' 硬刪除（不可還原）。"
+    read -r -p "輸入 'yes' 繼續：" answer
+    [[ "$answer" == "yes" ]] || { echo "[abort] 取消"; exit 5; }
+fi
+
+# ─── 3. 執行：單一 transaction，失敗自動 rollback ───
+echo "==> 開始刪除..."
+psql -e -v ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+
+CREATE TEMP TABLE _del_users AS
+SELECT id FROM user_profiles
+WHERE teacher_id IS NOT NULL OR student_id IS NOT NULL;
+
+-- 解開 bookings ↔ substitute_details 的循環 FK
+UPDATE bookings SET substitute_detail_id = NULL
+WHERE substitute_detail_id IS NOT NULL;
+
+-- L1: bookings 的子表
+DELETE FROM zoom_meeting_logs;
+DELETE FROM teacher_bonus_records;
+DELETE FROM substitute_details;
+DELETE FROM leave_records;
+DELETE FROM booking_details;
+
+-- L2: bookings (booking_calendar_events 自動 CASCADE)
+DELETE FROM bookings;
+
+-- L3: teacher 子表 (slots/schedules → contracts → 其他)
+DELETE FROM teacher_available_slots;
+DELETE FROM teacher_work_schedules;
+DELETE FROM teacher_contracts;        -- teacher_contract_details CASCADE
+DELETE FROM teacher_zoom_accounts;
+DELETE FROM teacher_details;
+
+-- L3: student 子表
+DELETE FROM student_courses;
+DELETE FROM student_teacher_preferences;
+DELETE FROM student_contracts;        -- student_contract_details / leave_records CASCADE
+DELETE FROM student_details;
+
+-- L3: 教師/學生對應的 user_profiles
+DELETE FROM user_profiles
+WHERE teacher_id IS NOT NULL OR student_id IS NOT NULL;
+
+-- L4: teachers, students
+DELETE FROM teachers;
+DELETE FROM students;
+
+-- L5: 對應 users (CASCADE 自動清 line_user_bindings / user_page_overrides 等)
+DELETE FROM users WHERE id IN (SELECT id FROM _del_users);
+
+COMMIT;
+SQL
+
+# ─── 4. 驗證後狀態 ───
+echo
+echo "==> 執行後狀態"
+psql -At <<'SQL' | column -t -s '|'
+SELECT 'teachers',              count(*) FROM teachers
+UNION ALL SELECT 'students',    count(*) FROM students
+UNION ALL SELECT 'bookings',    count(*) FROM bookings
+UNION ALL SELECT 'employees (kept)', count(*) FROM employees
+UNION ALL SELECT 'users (remaining)', count(*) FROM users
+UNION ALL SELECT 'user_profiles (remaining)', count(*) FROM user_profiles
+ORDER BY 1;
+SQL
+
+echo
+echo "✓ 完成"


### PR DESCRIPTION
此 PR 集合 backend 觀測性 / 時區一致性 / 安全 enforcement / 既有 bug 修補。

---

## 1. Logging 改善

### a. timestamp 換 Asia/Taipei、秒精度、移除 logger 欄位 (73a48a1)
```
舊: "timestamp": "2026-05-03T07:33:14.326932+00:00", "logger": "app.middleware.logging_middleware"
新: "timestamp": "2026-05-03T15:33:14+08:00"
```
`backend/app/core/logging.py` JSONFormatter 改用 `TAIPEI_TZ`，移除冗餘的 `logger` 欄位。

### b. HTTP status_code 獨立成頂層欄位 (ee4208a)
```json
{"timestamp":"...", "level":"INFO", "message":"GET /docs 200 7ms", "status_code": 200, ...}
```
LoggingMiddleware 透過 `extra={"status_code": ...}` 傳入；JSONFormatter 偵測到 record 上有此屬性即寫入。下游 log aggregator 可直接 filter `status_code:>=400`，不再需要 regex parse message。

---

## 2. 時區統一

### a. backend container TZ 改 Asia/Taipei (6467ab8)
DB 業務欄位 (`bookings.booking_date / start_time / end_time`、`zoom_meeting_logs.meeting_date / end_time`) 全部用 Taipei 本地時間語意。但 backend container 之前 TZ=UTC → `datetime.now()` 回 UTC → `auto_end_overdue_meetings` 比較 (Taipei vs UTC) 會晚 8 小時才 catch 超時會議。

設 `TZ=Asia/Taipei` 讓 `datetime.now()` 與 DB 業務時間對齊。明確使用 `datetime.now(timezone.utc)` 的地方不受影響。

副作用稽核 4 處 naive `datetime.now()`：
- `zoom_service:286` booking past-time 檢查 → 同時治好
- `zoom_service:965` auto_end → 主修
- `notification_service:149` `.year` → 不受影響
- `notification_service:180` sent_at → 從 naive UTC 改為 naive Taipei（`NOTIFICATION_ENABLED=false` 不影響運作）

### b. 同時啟用 pgadmin (6467ab8)
取消註解 `pgadmin` service：5050 → 80，預載 `pgadmin/servers.json` 自動連 `db:5432`。

### c. leave_records now 改用 datetime.now() (5f635fd)
container TZ 已對齊 Taipei，`datetime.utcnow() + timedelta(hours=8)` 手動換算可移除。順便消除 Python 3.12+ `utcnow()` deprecation warning。

---

## 3. 工具腳本

### scripts/db-purge-students-teachers.sh (c70bf9e)
本機 docker DB 硬刪 teacher / student / booking + 所有相關子表的腳本：
- `--dry-run` 預覽筆數
- `--yes` 跳過互動
- 預設拒絕非本機 container（要 `ALLOW_REMOTE=1` override）
- 單一 transaction，ON_ERROR_STOP，失敗自動 rollback
- 解開 bookings ↔ substitute_details 循環 FK
- 不刪 employees / courses / zoom_accounts 等共用資料

---

## 4. Bug 修補：teacher-slots update 衝突回 500 (5fb468a)

PR #42 修過 create 端點，但 update 端點漏修。改 slot 日期撞到另一個 slot 會回 500「系統發生異常」。

3 個 update 端點都補上 `asyncpg.exceptions.RaiseError` / `ExclusionViolationError` → 409：
- `PUT /teacher-slots/{slot_id}`
- `PUT /teacher-slots/batch`
- `POST /teacher-slots/batch-by-ids/update`

行為跟 PR #42 一致，Postgres trigger 中文訊息透傳。

---

## 5. is_active 業務 enforcement + 登入驗證 (406f684)

過去 `is_active` 在多數 endpoint 已 enforce，但有四個漏洞：

### a. POST /bookings & POST /bookings/batch
學生 / 老師驗證只看 `is_deleted`，被停用 entity 仍可建預約。前端下拉雖過濾 active，但 API 直接打可繞過。

加 filter `"is_active": "eq.true"`，訊息改「不存在或已停用」。

### b. POST /teacher-slots & POST /teacher-slots/batch
同上，建立教師時段也漏掉 `is_active` 檢查。停用老師仍可被排新時段。

### c. 登入流程 (auth_service.login + login_by_user_id)
完全沒檢查 `user_profiles.is_active` → 被停用帳號仍可登入並拿 cookie。

`_get_user_identity` 多撈 `is_active`；`login` 取得後 `is_active=false` 直接 raise `AuthException("帳號已停用，請聯絡管理員")`。

### d. DELETE /api/v1/users/{id} 停用帳號
之前只 set `is_active=false`，現有 cookie 仍能用到 session 過期。
順手呼叫 `session_service.destroy_all_user_sessions(user_id)` 主動清。

---

## 驗證

```
[Logger]
{"timestamp":"2026-05-03T15:45:27+08:00","level":"INFO","message":"GET /docs 200 7ms","status_code":200,...}

[TZ]
container date → Sun May 3 16:17:20 CST 2026
datetime.now() → 2026-05-03 16:17:21 (Taipei naive)
datetime.now(timezone.utc) → 2026-05-03 08:17:21+00:00 (仍 UTC)

[Slot conflict]
PUT slot D2 改 slot_date=D1 → HTTP 409 + Postgres trigger 訊息

[is_active]
POST /bookings inactive student → 400 "學生不存在或已停用"
POST /teacher-slots inactive teacher → 400 "教師不存在或已停用"
login user_profiles.is_active=false → "帳號已停用，請聯絡管理員"
```

## Test plan
- [x] curl 驗證 logger 新格式 + status_code 頂層欄位
- [x] container date 確認 CST
- [x] datetime.now() 在 container 內回 Taipei naive
- [x] curl 驗證 slot update 衝突 → 409
- [x] curl 驗證 inactive 學生 / 老師 / 帳號擋住
- [x] purge 腳本 --dry-run
- [ ] dev 部署後跑既有 e2e 確認沒 regression

---

## 6. teacher-slots 區分「部分預約」與「完全沒預約」(8837f9f, closes #52)

### 問題
`is_booked` 後端語意是「該 slot 完全滿」(`booked_count >= max_bookings`)、前端誤當「有任一預約」。
9:00–12:00 (180 min) + 60 min 課程 → max_bookings=3，預約 1 堂時 `is_booked=false` → UI 顯示「尚有空位」、看不出已被預約。

### 解法
採用 issue #52 推薦方向 B（多回傳 booking_count，前端區分三態），最小改動：

- 後端 `GET /teacher-slots` 與 `GET /teacher-slots/{id}` SELECT 多回 `booking_count`（非取消、非刪除）
- list 用一次 `GROUP BY teacher_slot_id` batch 查（不 N+1）
- `TeacherSlotResponse` schema 加 `booking_count: int = 0`
- 前端 `/teacher-slots` 顯示三態：
  - `is_booked=true` → 「預約已滿」（紅）
  - `booking_count > 0` → 「已預約 N 堂」（橙，新增）
  - 其他 → 「尚有空位」（黃）

`is_booked` 維護邏輯（bookings.py:1395-1414）不動，避免影響其他 reader。

### 驗證
E2E 全綠：booking_flow 38/38、contracts 35/35、courses 15/15、leave_flow 10/10、overtime 18/18、permission_realtime 17/17、student_flow 16/16、teacher_flow 25/25、trial_to_formal 13/13。


---

## 7. GET /bookings 回應補 student_no / student_eng_name (ac46bc2, closes #56)

### 問題
\`GET /api/v1/bookings\`（列表 + 詳情）只帶 \`student_name\`，前端顯示「王小明 (EOPS001)」格式或英文名都得再打 \`GET /students/{id}\` → N+1。

### 解法
- `BookingResponse` schema 加 `student_no`、`student_eng_name`（Optional）
- list 端點主 SQL（已有 students JOIN）多 SELECT `s.student_no, s.eng_name AS student_eng_name`，零額外 query
- `enrich_booking_with_relations`（detail / create / update 共用）改撈 `name,student_no,eng_name`，補對應 dict key
- frontend-dennis `Booking` interface 加對應欄位

### 驗證
```
GET /api/v1/bookings → student_name='試上轉正02', student_no='ST002', ...
GET /api/v1/bookings/{id} → student_name='試上轉正02', student_no='ST002', ...
```

E2E 全綠：booking_flow 38/38、contracts 35/35、courses 15/15、leave_flow 10/10、overtime 18/18、permission_realtime 17/17、student_flow 16/16、teacher_flow 25/25、trial_to_formal 13/13。
