### PR TITLE
feat: cancel-pending + 員工請假代申請 + course duration enum + 業務資料 purge

### DIFF
--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Path, Query, HTTPException
 from app.services.supabase_service import supabase_service
 from app.services.preference_service import preference_service
 from app.core.dependencies import get_current_user, CurrentUser, require_staff, require_page_permission, get_user_employee_id
@@ -6,7 +6,8 @@ from app.schemas.booking import (
     BookingCreate, BookingUpdate, BookingResponse, BookingListResponse, BookingStatus,
     BookingBatchUpdateByIds, BookingBatchUpdateResult,
     BookingBatchDeleteByIds, BookingBatchUpdate, BookingBatchDelete,
-    BookingBatchCreate, TimeBlock, SlotAvailabilityResponse
+    BookingBatchCreate, BookingCancelPendingResponse,
+    TimeBlock, SlotAvailabilityResponse
 )
 from app.schemas.response import BaseResponse, DataResponse, StudentOption, TeacherOption, CourseOption, ContractOption, TeacherContractOption, SlotOption
 from typing import Optional, List
@@ -2049,14 +2050,36 @@ async def delete_booking(
         raise HTTPException(status_code=500, detail=f"刪除預約失敗: {str(e)}")
 
 
-@router.post("/{booking_id}/cancel-pending", response_model=BaseResponse)
+@router.post(
+    "/{booking_id}/cancel-pending",
+    response_model=BookingCancelPendingResponse,
+    summary="取消待確認的預約",
+)
 async def cancel_pending_booking(
-    booking_id: str,
+    booking_id: str = Path(
+        ...,
+        description="要取消的預約 ID（UUID）",
+        examples=["a1b2c3d4-e5f6-7890-abcd-ef1234567890"],
+    ),
     current_user: CurrentUser = Depends(get_current_user),
 ):
-    """取消待確認的預約（員工 / 老師本人 / 學生本人）。
+    """取消待確認的預約。
 
-    confirmed 預約的取消請走請假流程；本端點只處理 pending → cancelled。
+    **權限**：
+    - 員工 (`is_staff`)：可取消任何 pending booking
+    - 老師 (`is_teacher`)：只能取消 `booking.teacher_id == self.teacher_id` 的 pending booking
+    - 學生 (`is_student`)：只能取消 `booking.student_id == self.student_id` 的 pending booking
+
+    **行為**：
+    - 將 `booking_status` 從 `pending` 改為 `cancelled`
+    - 觸發 `cancel_booking_side_effects`：堂數退回 + slot 釋放 + Zoom 取消（pending 通常無 Zoom，silent skip）
+
+    **僅處理** `pending → cancelled`。confirmed 預約的取消請走請假流程（`POST /leave-records`）。
+
+    **錯誤**：
+    - `404 預約不存在`
+    - `400 只有待確認的預約可以取消（已確認的請走請假流程）`
+    - `403 只能取消自己的預約`（非員工且不是該預約的學生 / 老師本人）
     """
     try:
         booking = await supabase_service.table_select(
@@ -2094,7 +2117,7 @@ async def cancel_pending_booking(
         # 共用副作用：堂數退回 + slot 釋放 + Zoom 取消（pending 通常無 Zoom，silent skip）
         await cancel_booking_side_effects(b)
 
-        return BaseResponse(message="預約已取消")
+        return BookingCancelPendingResponse(message="預約已取消")
 
     except HTTPException:
         raise

--- a/backend/app/api/v1/bookings.py
+++ b/backend/app/api/v1/bookings.py
@@ -2049,6 +2049,59 @@ async def delete_booking(
         raise HTTPException(status_code=500, detail=f"刪除預約失敗: {str(e)}")
 
 
+@router.post("/{booking_id}/cancel-pending", response_model=BaseResponse)
+async def cancel_pending_booking(
+    booking_id: str,
+    current_user: CurrentUser = Depends(get_current_user),
+):
+    """取消待確認的預約（員工 / 老師本人 / 學生本人）。
+
+    confirmed 預約的取消請走請假流程；本端點只處理 pending → cancelled。
+    """
+    try:
+        booking = await supabase_service.table_select(
+            table="bookings",
+            select="id,booking_status,student_id,teacher_id,student_contract_id,teacher_slot_id,lessons_used,booking_date,start_time",
+            filters={"id": booking_id, "is_deleted": "eq.false"},
+        )
+        if not booking:
+            raise HTTPException(status_code=404, detail="預約不存在")
+        b = booking[0]
+
+        if b.get("booking_status") != "pending":
+            raise HTTPException(
+                status_code=400,
+                detail="只有待確認的預約可以取消（已確認的請走請假流程）",
+            )
+
+        # role-aware 授權：staff 全可；老師 / 學生只能取消自己參與的
+        if not current_user.is_staff():
+            booking_student_id = str(b.get("student_id")) if b.get("student_id") else None
+            booking_teacher_id = str(b.get("teacher_id")) if b.get("teacher_id") else None
+            is_owner = (
+                (current_user.is_teacher() and current_user.teacher_id == booking_teacher_id)
+                or (current_user.is_student() and current_user.student_id == booking_student_id)
+            )
+            if not is_owner:
+                raise HTTPException(status_code=403, detail="只能取消自己的預約")
+
+        await supabase_service.table_update(
+            table="bookings",
+            data={"booking_status": "cancelled"},
+            filters={"id": booking_id},
+        )
+
+        # 共用副作用：堂數退回 + slot 釋放 + Zoom 取消（pending 通常無 Zoom，silent skip）
+        await cancel_booking_side_effects(b)
+
+        return BaseResponse(message="預約已取消")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"取消預約失敗: {str(e)}")
+
+
 # ============================================
 # 批次操作 API
 # ============================================

--- a/backend/app/api/v1/leave_records.py
+++ b/backend/app/api/v1/leave_records.py
@@ -184,6 +184,36 @@ async def create_leave_record(
         if existing_leave:
             raise HTTPException(status_code=400, detail="此預約已有待審核的請假申請")
 
+        # === 先決定 initiator_type（緊急請假豁免邏輯依賴它）===
+        if current_user.is_student():
+            if booking[0].get("student_id") != current_user.student_id:
+                raise HTTPException(status_code=403, detail="學生只能為自己的預約請假")
+            initiator_type = "student"
+            initiator_student_id = current_user.student_id
+            initiator_teacher_id = None
+        elif current_user.is_teacher():
+            if booking[0].get("teacher_id") != current_user.teacher_id:
+                raise HTTPException(status_code=403, detail="教師只能為自己的預約請假")
+            initiator_type = "teacher"
+            initiator_student_id = None
+            initiator_teacher_id = current_user.teacher_id
+        elif current_user.is_staff():
+            # 員工代申請：必須指定 initiator_type=student 或 teacher
+            if data.initiator_type not in ("student", "teacher"):
+                raise HTTPException(
+                    status_code=400,
+                    detail="員工代申請請假時須指定 initiator_type=student 或 teacher",
+                )
+            initiator_type = data.initiator_type
+            if initiator_type == "student":
+                initiator_student_id = booking[0].get("student_id")
+                initiator_teacher_id = None
+            else:
+                initiator_student_id = None
+                initiator_teacher_id = booking[0].get("teacher_id")
+        else:
+            raise HTTPException(status_code=403, detail="無權建立請假申請")
+
         # === 時間判定：正常 / 緊急 / 禁止 ===
         booking_date_str = booking[0].get("booking_date")  # "2026-03-20" or date obj
         booking_start_str = booking[0].get("start_time")    # "14:00:00" or time obj
@@ -208,9 +238,9 @@ async def create_leave_record(
             leave_type = "emergency"
             deduct_lesson = False
             # 緊急請假額度綁在學生合約上：
-            # - 老師發起：不消耗學生額度，跳過合約檢查
-            # - 學生 / 員工代申請：須檢查該預約對應的學生合約額度
-            if current_user.is_teacher():
+            # - 老師發起（含員工代老師申請）：不消耗學生額度，跳過合約檢查
+            # - 學生發起 / 員工代學生申請：須檢查該預約對應的學生合約額度
+            if initiator_type == "teacher":
                 emergency_quota = None
                 used_emergency_count = None
             else:
@@ -287,27 +317,6 @@ async def create_leave_record(
                         status_code=400,
                         detail="此預約查無對應的學生合約，無法申請緊急請假",
                     )
-
-        # 判斷發起者類型
-        if current_user.is_student():
-            if booking[0].get("student_id") != current_user.student_id:
-                raise HTTPException(status_code=403, detail="學生只能為自己的預約請假")
-            initiator_type = "student"
-            initiator_student_id = current_user.student_id
-            initiator_teacher_id = None
-        elif current_user.is_teacher():
-            if booking[0].get("teacher_id") != current_user.teacher_id:
-                raise HTTPException(status_code=403, detail="教師只能為自己的預約請假")
-            initiator_type = "teacher"
-            initiator_student_id = None
-            initiator_teacher_id = current_user.teacher_id
-        elif current_user.is_staff():
-            # 員工代為申請，預設以學生身份
-            initiator_type = "student"
-            initiator_student_id = booking[0].get("student_id")
-            initiator_teacher_id = None
-        else:
-            raise HTTPException(status_code=403, detail="無權建立請假申請")
 
         leave_no = await generate_leave_no()
         employee_id = await get_user_employee_id(current_user.user_id)

--- a/backend/app/schemas/booking.py
+++ b/backend/app/schemas/booking.py
@@ -182,6 +182,21 @@ class BookingListResponse(BaseModel):
     total_pages: int = 0
 
 
+class BookingCancelPendingResponse(BaseModel):
+    """取消待確認預約的回應（POST /bookings/{id}/cancel-pending）"""
+    success: bool = True
+    message: str = "預約已取消"
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [{
+                "success": True,
+                "message": "預約已取消",
+            }]
+        }
+    }
+
+
 class BookingBatchUpdateByIds(BaseModel):
     """根據 ID 批次更新預約狀態"""
     booking_ids: List[str] = Field(..., description="預約 ID 列表")

--- a/backend/app/schemas/course.py
+++ b/backend/app/schemas/course.py
@@ -1,13 +1,16 @@
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Literal, Optional
 from datetime import datetime
+
+# 業務上課程只有 30 分鐘 / 60 分鐘兩種；其他值 schema + DB CHECK 雙重擋掉
+CourseDuration = Literal[30, 60]
 
 
 class CourseBase(BaseModel):
     course_code: str = Field(..., min_length=1, max_length=50, description="課程代碼")
     course_name: str = Field(..., min_length=1, max_length=200, description="課程名稱")
     description: Optional[str] = Field(None, description="課程描述")
-    duration_minutes: int = Field(60, ge=15, le=480, description="課程時長（分鐘）")
+    duration_minutes: CourseDuration = Field(60, description="課程時長（分鐘，只允許 30 或 60）")
     is_active: bool = Field(True, description="是否啟用")
 
 
@@ -31,14 +34,14 @@ class CourseUpdate(BaseModel):
     course_code: Optional[str] = Field(None, min_length=1, max_length=50)
     course_name: Optional[str] = Field(None, min_length=1, max_length=200)
     description: Optional[str] = None
-    duration_minutes: Optional[int] = Field(None, ge=15, le=480)
+    duration_minutes: Optional[CourseDuration] = Field(None, description="課程時長（分鐘，只允許 30 或 60）")
     is_active: Optional[bool] = None
 
     model_config = {
         "json_schema_extra": {
             "examples": [{
                 "course_name": "英語日常會話（進階）",
-                "duration_minutes": 90,
+                "duration_minutes": 30,
             }]
         }
     }

--- a/backend/app/schemas/leave_record.py
+++ b/backend/app/schemas/leave_record.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Literal, Optional
 from datetime import datetime, date, time
 from enum import Enum
 
@@ -19,12 +19,17 @@ class LeaveInitiatorType(str, Enum):
 class LeaveRecordCreate(BaseModel):
     booking_id: str = Field(..., description="預約 ID")
     reason: str = Field(..., min_length=1, description="請假原因")
+    initiator_type: Optional[Literal["student", "teacher"]] = Field(
+        None,
+        description="代申請對象（僅員工呼叫時必填，學生 / 老師呼叫時自動由角色推斷，忽略此欄位）",
+    )
 
     model_config = {
         "json_schema_extra": {
             "examples": [{
                 "booking_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
                 "reason": "身體不適，需要請假一次",
+                "initiator_type": "student",
             }]
         }
     }

--- a/backend/tests/e2e/live_e2e_courses_test.py
+++ b/backend/tests/e2e/live_e2e_courses_test.py
@@ -82,6 +82,8 @@ class CoursesEnrollmentTester:
             await self._test("修改課程（改名）", self._update_course)
             await self._test("驗證修改結果", self._verify_course_update)
             await self._test("重複建立同 code（應拒絕）", self._reject_duplicate)
+            await self._test("無效 duration（90）→ 422", self._reject_invalid_duration)
+            await self._test("有效 duration 30 → 200", self._create_30min_course)
 
             # Prereq: 建立學生
             print(f"\n  Prereq: 建立學生")
@@ -171,6 +173,28 @@ class CoursesEnrollmentTester:
         })
         if resp.status_code == 400: return True
         return f"expected 400, got {resp.status_code}"
+
+    async def _reject_invalid_duration(self):
+        resp = await self._post("/api/v1/courses", {
+            "course_code": f"{TEST_PREFIX}C90",
+            "course_name": f"{TEST_PREFIX}invalid duration",
+            "duration_minutes": 90,
+        })
+        if resp.status_code != 422:
+            return f"expected 422, got {resp.status_code}: {resp.text[:200]}"
+        return True
+
+    async def _create_30min_course(self):
+        resp = await self._post("/api/v1/courses", {
+            "course_code": f"{TEST_PREFIX}C30",
+            "course_name": f"{TEST_PREFIX}短堂",
+            "duration_minutes": 30,
+        })
+        if resp.status_code != 200:
+            return f"{resp.status_code} {resp.text[:200]}"
+        if resp.json()["data"].get("duration_minutes") != 30:
+            return f"duration={resp.json()['data'].get('duration_minutes')}"
+        return True
 
     # ── Student ──
 

--- a/backend/tests/e2e/live_e2e_leave_flow_test.py
+++ b/backend/tests/e2e/live_e2e_leave_flow_test.py
@@ -166,6 +166,7 @@ class LeaveFlowTester:
             print("  " + "-" * 40)
             await self._test("緊急請假超額 → 400 拒絕", self._reject_over_quota)
             await self._test("課前 <30min → 400 禁止請假", self._reject_blocked)
+            await self._test("員工沒帶 initiator_type → 400", self._reject_staff_no_initiator_type)
 
             # Phase 4: 查詢驗證
             print(f"\n  Phase 4: 查詢驗證")
@@ -174,6 +175,12 @@ class LeaveFlowTester:
             await self._test("單筆查詢欄位正確", self._verify_single)
             await self._test("合約 emergency_leave_quota 正確", self._verify_contract_quota)
             await self._test("補償堂數計入 emergency_leave_quota", self._verify_quota_with_compensation)
+
+            # Phase 5: 員工代老師申請（豁免學生額度）
+            print(f"\n  Phase 5: 員工代老師申請緊急請假（豁免學生額度）")
+            print("  " + "-" * 40)
+            await self._test("員工帶 initiator_type=teacher 緊急請假（quota 已滿）", self._create_staff_as_teacher_emergency)
+            await self._test("核准員工代老師申請 → 不消耗學生額度", self._approve_staff_as_teacher_emergency)
 
             # Cleanup
             print(f"\n  Cleanup")
@@ -309,6 +316,7 @@ class LeaveFlowTester:
     async def _create_normal_leave(self):
         resp = await self._post("/api/v1/leave-records", {
             "booking_id": self.booking_a_id, "reason": f"{TEST_PREFIX} 正常請假",
+            "initiator_type": "student",
         })
         if resp.status_code != 200:
             return f"{resp.status_code} {resp.text[:200]}"
@@ -339,6 +347,7 @@ class LeaveFlowTester:
     async def _create_emergency_within_quota(self):
         resp = await self._post("/api/v1/leave-records", {
             "booking_id": self.booking_b_id, "reason": f"{TEST_PREFIX} 緊急請假",
+            "initiator_type": "student",
         })
         if resp.status_code != 200:
             return f"{resp.status_code} {resp.text[:200]}"
@@ -371,6 +380,7 @@ class LeaveFlowTester:
     async def _reject_over_quota(self):
         resp = await self._post("/api/v1/leave-records", {
             "booking_id": self.booking_c_id, "reason": f"{TEST_PREFIX} 超額",
+            "initiator_type": "student",
         })
         if resp.status_code != 400:
             return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
@@ -382,11 +392,25 @@ class LeaveFlowTester:
     async def _reject_blocked(self):
         resp = await self._post("/api/v1/leave-records", {
             "booking_id": self.booking_d_id, "reason": f"{TEST_PREFIX} 太晚",
+            "initiator_type": "student",
         })
         if resp.status_code != 400:
             return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
         msg = self._err_msg(resp)
         if "30" not in msg and "分鐘" not in msg:
+            return f"wrong message: {msg}"
+        return True
+
+    async def _reject_staff_no_initiator_type(self):
+        """員工 POST 不帶 initiator_type → 400（檢查順序：在時間/額度檢查前）"""
+        resp = await self._post("/api/v1/leave-records", {
+            "booking_id": self.booking_d_id, "reason": f"{TEST_PREFIX} no type",
+            # 不帶 initiator_type
+        })
+        if resp.status_code != 400:
+            return f"expected 400, got {resp.status_code}: {resp.text[:200]}"
+        msg = self._err_msg(resp)
+        if "initiator_type" not in msg:
             return f"wrong message: {msg}"
         return True
 
@@ -484,6 +508,53 @@ class LeaveFlowTester:
         d = r.json()["data"]
         if d.get("emergency_leave_quota") != 1:
             return f"after delete: quota={d.get('emergency_leave_quota')}, expected 1"
+        return True
+
+    # ── Phase 5: 員工代老師申請 ──
+
+    async def _create_staff_as_teacher_emergency(self):
+        """booking_c 學生 quota 已用完（_reject_over_quota 已驗證），
+        但員工帶 initiator_type=teacher 應豁免合約檢查，直接成功"""
+        resp = await self._post("/api/v1/leave-records", {
+            "booking_id": self.booking_c_id, "reason": f"{TEST_PREFIX} 員工代老師申請",
+            "initiator_type": "teacher",
+        })
+        if resp.status_code != 200:
+            return f"{resp.status_code} {resp.text[:200]}"
+        data = resp.json().get("data", {})
+        self.leave_staff_teacher_id = data.get("id")
+        if data.get("initiator_type") != "teacher":
+            return f"initiator_type={data.get('initiator_type')}, expected teacher"
+        if data.get("initiator_teacher_id") != self.teacher_id:
+            return f"initiator_teacher_id={data.get('initiator_teacher_id')}, expected {self.teacher_id}"
+        if data.get("initiator_student_id") is not None:
+            return f"initiator_student_id should be None, got {data.get('initiator_student_id')}"
+        if data.get("leave_type") != "emergency":
+            return f"leave_type={data.get('leave_type')}, expected emergency"
+        return True
+
+    async def _approve_staff_as_teacher_emergency(self):
+        """核准員工代老師申請的緊急請假 → 學生額度不消耗、不寫 student_contract_leave_records"""
+        before = get_contract_state(self.student_contract_id)
+        sclr_before = int(db_value(
+            f"SELECT COUNT(*) FROM student_contract_leave_records "
+            f"WHERE student_contract_id = '{self.student_contract_id}' AND is_deleted = FALSE"
+        ) or 0)
+        resp = await self._post(f"/api/v1/leave-records/{self.leave_staff_teacher_id}/approve")
+        if resp.status_code != 200:
+            return f"approve failed: {resp.status_code} {resp.text[:200]}"
+        after = get_contract_state(self.student_contract_id)
+        if after["used_emergency_leave_count"] != before["used_emergency_leave_count"]:
+            return (
+                f"used_emergency_leave_count changed: "
+                f"{before['used_emergency_leave_count']}→{after['used_emergency_leave_count']}（teacher initiator 應豁免）"
+            )
+        sclr_after = int(db_value(
+            f"SELECT COUNT(*) FROM student_contract_leave_records "
+            f"WHERE student_contract_id = '{self.student_contract_id}' AND is_deleted = FALSE"
+        ) or 0)
+        if sclr_after != sclr_before:
+            return f"student_contract_leave_records 不應新增（teacher initiator）: {sclr_before}→{sclr_after}"
         return True
 
     # ── Cleanup ──

--- a/frontend-dennis/src/app/bookings/page.tsx
+++ b/frontend-dennis/src/app/bookings/page.tsx
@@ -2264,6 +2264,7 @@ export default function BookingsPage() {
                     <LeaveModal
                         bookingId={leaveBooking.id}
                         bookingNo={leaveBooking.booking_no}
+                        isStaff={isStaff}
                         onClose={() => setLeaveBooking(null)}
                         onSuccess={() => { setLeaveBooking(null); fetchBookings() }}
                     />

--- a/frontend-dennis/src/app/bookings/page.tsx
+++ b/frontend-dennis/src/app/bookings/page.tsx
@@ -171,6 +171,8 @@ export default function BookingsPage() {
     const [leaveBooking, setLeaveBooking] = useState<Booking | null>(null)
     const [substituteBooking, setSubstituteBooking] = useState<Booking | null>(null)
     const [cancelBooking, setCancelBooking] = useState<Booking | null>(null)
+    const [cancelPendingConfirm, setCancelPendingConfirm] = useState<Booking | null>(null)
+    const [cancelingPending, setCancelingPending] = useState(false)
     const [reviewLeaveRecord, setReviewLeaveRecord] = useState<LeaveRecord | null>(null)
 
     // Zoom meeting info
@@ -584,6 +586,19 @@ export default function BookingsPage() {
         if (error) {
             setError(error.message)
         } else {
+            fetchBookings()
+        }
+    }
+
+    const handleCancelPending = async () => {
+        if (!cancelPendingConfirm) return
+        setCancelingPending(true)
+        const { error } = await bookingsApi.cancelPending(cancelPendingConfirm.id)
+        setCancelingPending(false)
+        if (error) {
+            setError(error.message)
+        } else {
+            setCancelPendingConfirm(null)
             fetchBookings()
         }
     }
@@ -1703,6 +1718,16 @@ export default function BookingsPage() {
                                                                         </button>
                                                                     </>
                                                                 )}
+                                                                {booking.booking_status === 'pending' && (
+                                                                    <button
+                                                                        onClick={() => setCancelPendingConfirm(booking)}
+                                                                        className="inline-flex items-center px-2 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 rounded"
+                                                                        title="取消待確認預約"
+                                                                    >
+                                                                        <Ban className="w-3.5 h-3.5 mr-0.5" />
+                                                                        取消
+                                                                    </button>
+                                                                )}
                                                                 <button
                                                                     onClick={() => openEditModal(booking)}
                                                                     className="text-blue-600 hover:text-blue-900 p-1"
@@ -1734,14 +1759,24 @@ export default function BookingsPage() {
                                                                     </button>
                                                                 )}
                                                                 {booking.booking_status === 'pending' && (
-                                                                    <button
-                                                                        onClick={() => handleTeacherConfirm(booking)}
-                                                                        className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md"
-                                                                        title="確認預約"
-                                                                    >
-                                                                        <CheckCircle className="w-4 h-4 mr-1" />
-                                                                        確認
-                                                                    </button>
+                                                                    <>
+                                                                        <button
+                                                                            onClick={() => handleTeacherConfirm(booking)}
+                                                                            className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-md"
+                                                                            title="確認預約"
+                                                                        >
+                                                                            <CheckCircle className="w-4 h-4 mr-1" />
+                                                                            確認
+                                                                        </button>
+                                                                        <button
+                                                                            onClick={() => setCancelPendingConfirm(booking)}
+                                                                            className="inline-flex items-center px-2 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 rounded"
+                                                                            title="取消待確認預約"
+                                                                        >
+                                                                            <Ban className="w-3.5 h-3.5 mr-0.5" />
+                                                                            取消
+                                                                        </button>
+                                                                    </>
                                                                 )}
                                                                 {booking.booking_status !== 'pending' && booking.booking_status !== 'confirmed' && (
                                                                     <span className="text-sm text-gray-400">-</span>
@@ -1751,18 +1786,31 @@ export default function BookingsPage() {
                                                     )}
                                                     {isStudent && (
                                                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                                            {booking.booking_status === 'confirmed' ? (
-                                                                <button
-                                                                    onClick={() => setLeaveBooking(booking)}
-                                                                    className="inline-flex items-center px-2 py-1 text-xs font-medium text-yellow-700 bg-yellow-50 hover:bg-yellow-100 rounded"
-                                                                    title="請假"
-                                                                >
-                                                                    <UserMinus className="w-3.5 h-3.5 mr-0.5" />
-                                                                    請假
-                                                                </button>
-                                                            ) : (
-                                                                <span className="text-sm text-gray-400">-</span>
-                                                            )}
+                                                            <div className="flex items-center justify-end gap-1">
+                                                                {booking.booking_status === 'confirmed' && (
+                                                                    <button
+                                                                        onClick={() => setLeaveBooking(booking)}
+                                                                        className="inline-flex items-center px-2 py-1 text-xs font-medium text-yellow-700 bg-yellow-50 hover:bg-yellow-100 rounded"
+                                                                        title="請假"
+                                                                    >
+                                                                        <UserMinus className="w-3.5 h-3.5 mr-0.5" />
+                                                                        請假
+                                                                    </button>
+                                                                )}
+                                                                {booking.booking_status === 'pending' && (
+                                                                    <button
+                                                                        onClick={() => setCancelPendingConfirm(booking)}
+                                                                        className="inline-flex items-center px-2 py-1 text-xs font-medium text-red-700 bg-red-50 hover:bg-red-100 rounded"
+                                                                        title="取消待確認預約"
+                                                                    >
+                                                                        <Ban className="w-3.5 h-3.5 mr-0.5" />
+                                                                        取消
+                                                                    </button>
+                                                                )}
+                                                                {booking.booking_status !== 'confirmed' && booking.booking_status !== 'pending' && (
+                                                                    <span className="text-sm text-gray-400">-</span>
+                                                                )}
+                                                            </div>
                                                         </td>
                                                     )}
                                                 </tr>
@@ -2241,6 +2289,35 @@ export default function BookingsPage() {
                         onClose={() => setCancelBooking(null)}
                         onSuccess={() => { setCancelBooking(null); fetchBookings() }}
                     />
+                )}
+
+                {/* 取消待確認預約 confirm */}
+                {cancelPendingConfirm && (
+                    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+                        <div className="bg-white rounded-xl shadow-xl max-w-md w-full p-6">
+                            <h3 className="text-lg font-bold text-gray-900 mb-2">取消待確認預約</h3>
+                            <p className="text-sm text-gray-600 mb-2">預約編號：<span className="font-mono">{cancelPendingConfirm.booking_no}</span></p>
+                            <div className="bg-red-50 border border-red-200 rounded-md p-3 my-3">
+                                <p className="text-sm text-red-700">將取消這筆待確認預約，堂數會退回、時段會釋放，此操作無法復原。</p>
+                            </div>
+                            <div className="flex justify-end gap-3">
+                                <button
+                                    onClick={() => setCancelPendingConfirm(null)}
+                                    disabled={cancelingPending}
+                                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md disabled:opacity-50"
+                                >
+                                    返回
+                                </button>
+                                <button
+                                    onClick={handleCancelPending}
+                                    disabled={cancelingPending}
+                                    className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md disabled:opacity-50"
+                                >
+                                    {cancelingPending ? '取消中...' : '確認取消'}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                 )}
 
                 {/* 請假審核 Modal */}

--- a/frontend-dennis/src/app/courses/page.tsx
+++ b/frontend-dennis/src/app/courses/page.tsx
@@ -443,14 +443,14 @@ export default function CoursesPage() {
                                         <label className="block text-sm font-medium text-gray-700 mb-1">
                                             課程時長（分鐘）
                                         </label>
-                                        <input
-                                            type="number"
+                                        <select
                                             value={formData.duration_minutes}
-                                            onChange={(e) => setFormData({ ...formData, duration_minutes: parseInt(e.target.value) || 60 })}
+                                            onChange={(e) => setFormData({ ...formData, duration_minutes: parseInt(e.target.value) })}
                                             className="input-field"
-                                            min={15}
-                                            max={480}
-                                        />
+                                        >
+                                            <option value={30}>30 分鐘</option>
+                                            <option value={60}>60 分鐘</option>
+                                        </select>
                                     </div>
 
                                     <div className="flex items-center">

--- a/frontend-dennis/src/components/booking/LeaveModal.tsx
+++ b/frontend-dennis/src/components/booking/LeaveModal.tsx
@@ -7,12 +7,14 @@ import { leaveRecordsApi, LeaveRecord } from '@/lib/api/leaveRecords'
 interface LeaveModalProps {
     bookingId: string
     bookingNo: string
+    isStaff?: boolean
     onClose: () => void
     onSuccess: () => void
 }
 
-export default function LeaveModal({ bookingId, bookingNo, onClose, onSuccess }: LeaveModalProps) {
+export default function LeaveModal({ bookingId, bookingNo, isStaff = false, onClose, onSuccess }: LeaveModalProps) {
     const [reason, setReason] = useState('')
+    const [initiatorType, setInitiatorType] = useState<'student' | 'teacher' | ''>('')
     const [submitting, setSubmitting] = useState(false)
     const [error, setError] = useState<string | null>(null)
     const [result, setResult] = useState<LeaveRecord | null>(null)
@@ -22,12 +24,17 @@ export default function LeaveModal({ bookingId, bookingNo, onClose, onSuccess }:
             setError('請填寫請假原因')
             return
         }
+        if (isStaff && !initiatorType) {
+            setError('請選擇代申請對象（幫學生 / 幫老師）')
+            return
+        }
         setSubmitting(true)
         setError(null)
 
         const { data, error: apiError } = await leaveRecordsApi.create({
             booking_id: bookingId,
             reason: reason.trim(),
+            ...(isStaff && initiatorType ? { initiator_type: initiatorType } : {}),
         })
 
         if (apiError) {
@@ -62,6 +69,40 @@ export default function LeaveModal({ bookingId, bookingNo, onClose, onSuccess }:
                                 <label className="block text-sm font-medium text-gray-700 mb-1">預約編號</label>
                                 <p className="text-sm text-gray-900 font-mono bg-gray-100 px-3 py-2 rounded">{bookingNo}</p>
                             </div>
+                            {isStaff && (
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                                        代申請對象 <span className="text-red-500">*</span>
+                                    </label>
+                                    <div className="flex gap-4">
+                                        <label className="inline-flex items-center cursor-pointer">
+                                            <input
+                                                type="radio"
+                                                name="initiator_type"
+                                                value="student"
+                                                checked={initiatorType === 'student'}
+                                                onChange={() => setInitiatorType('student')}
+                                                className="mr-2"
+                                            />
+                                            <span className="text-sm text-gray-700">幫學生請假</span>
+                                        </label>
+                                        <label className="inline-flex items-center cursor-pointer">
+                                            <input
+                                                type="radio"
+                                                name="initiator_type"
+                                                value="teacher"
+                                                checked={initiatorType === 'teacher'}
+                                                onChange={() => setInitiatorType('teacher')}
+                                                className="mr-2"
+                                            />
+                                            <span className="text-sm text-gray-700">幫老師請假</span>
+                                        </label>
+                                    </div>
+                                    <p className="text-xs text-gray-500 mt-1">
+                                        幫老師請假時，緊急請假不會消耗學生合約額度。
+                                    </p>
+                                </div>
+                            )}
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-1">
                                     請假原因 <span className="text-red-500">*</span>

--- a/frontend-dennis/src/lib/api/bookings.ts
+++ b/frontend-dennis/src/lib/api/bookings.ts
@@ -224,6 +224,9 @@ export const bookingsApi = {
     delete: (bookingId: string) =>
         apiDelete(`/api/v1/bookings/${bookingId}`, '刪除預約失敗'),
 
+    cancelPending: (bookingId: string) =>
+        apiPost(`/api/v1/bookings/${bookingId}/cancel-pending`, undefined, '取消待確認預約失敗'),
+
     // 批次操作 API
     createBatch: (data: BatchCreateData) =>
         apiAction('POST', '/api/v1/bookings/batch', data, '批次建立預約失敗'),

--- a/frontend-dennis/src/lib/api/leaveRecords.ts
+++ b/frontend-dennis/src/lib/api/leaveRecords.ts
@@ -40,7 +40,7 @@ export interface LeaveRecordListResponse {
 }
 
 export const leaveRecordsApi = {
-    create: (data: { booking_id: string; reason: string }) =>
+    create: (data: { booking_id: string; reason: string; initiator_type?: 'student' | 'teacher' }) =>
         apiPost<LeaveRecord>('/api/v1/leave-records', data, '建立請假申請失敗'),
 
     list: (params?: { page?: number; per_page?: number; leave_status?: LeaveStatus }) =>

--- a/scripts/db-purge-business-data.sh
+++ b/scripts/db-purge-business-data.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# 硬刪除所有「業務資料」（合約、預約、請假、代課、獎金、附約 等），
+# 但完整保留所有帳號與實體（teachers / students / employees / users / 角色 / 權限）。
+#
+# 適用情境：跑過幾輪測試後想把預約/合約/堂數歸零，但不想重新建學生/老師/帳號。
+#
+# 保留：
+#   • users / user_profiles / line_user_bindings / user_page_overrides
+#   • employees / teachers / students（實體 row）
+#   • roles / role_pages / page_permissions
+#   • courses（課程主檔）
+#   • google_drive_config / zoom_accounts / teacher_zoom_accounts（帳號/授權狀態）
+#   • teacher_details / student_details（人員 profile 上傳檔資訊）
+#   • notification_preferences（使用者通知偏好）
+#   • _migrations / auto_number_sequences 相關
+#
+# 硬刪除（單一 transaction，失敗 rollback）：
+#   • bookings + 子表（zoom_meeting_logs / teacher_bonus_records / substitute_details /
+#                     leave_records / booking_details / booking_calendar_events CASCADE）
+#   • teacher_available_slots / teacher_work_schedules
+#   • contract_addendums（polymorphic FK，不會 CASCADE，必須先刪）
+#   • teacher_contracts（teacher_contract_details CASCADE）
+#   • student_contracts（student_contract_details / student_contract_leave_records CASCADE）
+#   • student_courses / student_teacher_preferences
+#   • notification_logs / line_notification_logs / notification_queue / system_alerts
+#
+# 使用方式：
+#   ./scripts/db-purge-business-data.sh                       # 互動式確認
+#   ./scripts/db-purge-business-data.sh --yes                 # 跳過確認 (CI/cron 用)
+#   ./scripts/db-purge-business-data.sh --dry-run             # 只顯示會刪幾筆，不實際刪
+#   CONTAINER=teaching-platform-db ./scripts/db-purge-business-data.sh   # 自訂 container 名
+#
+# ⚠️ 動作不可逆。預設拒絕在非本機環境跑：
+#    - 必須能 docker exec 到 ${CONTAINER}
+#    - CONTAINER 名稱必須含 'teaching-platform' 或 'local'
+#    - 若想跑遠端，自行 export ALLOW_REMOTE=1 並對自己風險負責
+
+set -euo pipefail
+
+CONTAINER="${CONTAINER:-teaching-platform-db}"
+PG_USER="${PG_USER:-postgres}"
+PG_DB="${PG_DB:-postgres}"
+
+DRY_RUN=0
+ASSUME_YES=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --yes|-y) ASSUME_YES=1 ;;
+        -h|--help) sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
+# Safety: 拒絕在 production 風格的 container 名稱跑
+if [[ "$CONTAINER" != *"local"* && "$CONTAINER" != *"teaching-platform"* && "${ALLOW_REMOTE:-0}" != "1" ]]; then
+    echo "[abort] CONTAINER='$CONTAINER' 不像本機 docker，請設 ALLOW_REMOTE=1 自行確認再跑" >&2
+    exit 3
+fi
+
+if ! docker exec "$CONTAINER" true >/dev/null 2>&1; then
+    echo "[abort] 連不到 container '$CONTAINER'" >&2
+    exit 4
+fi
+
+psql() {
+    docker exec -i "$CONTAINER" psql -U "$PG_USER" -d "$PG_DB" "$@"
+}
+
+# ─── 1. 預覽：列出將被影響的筆數 ───
+echo "==> 影響範圍（執行前）"
+psql -At <<'SQL' | column -t -s '|'
+SELECT 'bookings',                count(*) FROM bookings
+UNION ALL SELECT 'zoom_meeting_logs',       count(*) FROM zoom_meeting_logs
+UNION ALL SELECT 'teacher_bonus_records',   count(*) FROM teacher_bonus_records
+UNION ALL SELECT 'substitute_details',      count(*) FROM substitute_details
+UNION ALL SELECT 'leave_records',           count(*) FROM leave_records
+UNION ALL SELECT 'booking_details',         count(*) FROM booking_details
+UNION ALL SELECT 'teacher_available_slots', count(*) FROM teacher_available_slots
+UNION ALL SELECT 'teacher_work_schedules',  count(*) FROM teacher_work_schedules
+UNION ALL SELECT 'contract_addendums',      count(*) FROM contract_addendums
+UNION ALL SELECT 'teacher_contracts',       count(*) FROM teacher_contracts
+UNION ALL SELECT 'teacher_contract_details',count(*) FROM teacher_contract_details
+UNION ALL SELECT 'student_contracts',       count(*) FROM student_contracts
+UNION ALL SELECT 'student_contract_details',count(*) FROM student_contract_details
+UNION ALL SELECT 'student_contract_leave_records', count(*) FROM student_contract_leave_records
+UNION ALL SELECT 'student_courses',         count(*) FROM student_courses
+UNION ALL SELECT 'student_teacher_preferences', count(*) FROM student_teacher_preferences
+UNION ALL SELECT 'notification_logs',       count(*) FROM notification_logs
+UNION ALL SELECT 'line_notification_logs',  count(*) FROM line_notification_logs
+UNION ALL SELECT 'notification_queue',      count(*) FROM notification_queue
+UNION ALL SELECT 'system_alerts',           count(*) FROM system_alerts
+ORDER BY 1;
+SQL
+echo
+
+echo "==> 保留不動（執行前後皆相同）"
+psql -At <<'SQL' | column -t -s '|'
+SELECT 'users',         count(*) FROM users
+UNION ALL SELECT 'employees',   count(*) FROM employees
+UNION ALL SELECT 'teachers',    count(*) FROM teachers
+UNION ALL SELECT 'students',    count(*) FROM students
+UNION ALL SELECT 'roles',       count(*) FROM roles
+UNION ALL SELECT 'pages',       count(*) FROM pages
+UNION ALL SELECT 'courses',     count(*) FROM courses
+ORDER BY 1;
+SQL
+echo
+
+if [[ "$DRY_RUN" == "1" ]]; then
+    echo "[dry-run] 結束，未實際刪除"
+    exit 0
+fi
+
+# ─── 2. 互動確認 ───
+if [[ "$ASSUME_YES" != "1" ]]; then
+    echo "⚠️  以上業務資料即將從 container '$CONTAINER' 硬刪除（不可還原）。"
+    echo "    所有 user / teacher / student / employee 帳號跟角色權限會原封不動保留。"
+    read -r -p "輸入 'yes' 繼續：" answer
+    [[ "$answer" == "yes" ]] || { echo "[abort] 取消"; exit 5; }
+fi
+
+# ─── 3. 執行：單一 transaction，失敗自動 rollback ───
+echo "==> 開始刪除..."
+psql -e -v ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+
+-- 解開 bookings ↔ substitute_details 的循環 FK
+UPDATE bookings SET substitute_detail_id = NULL
+WHERE substitute_detail_id IS NOT NULL;
+
+-- L1: bookings 的子表
+DELETE FROM zoom_meeting_logs;
+DELETE FROM teacher_bonus_records;
+DELETE FROM substitute_details;
+DELETE FROM leave_records;
+DELETE FROM booking_details;
+
+-- L2: bookings (booking_calendar_events 自動 CASCADE)
+DELETE FROM bookings;
+
+-- L3: teacher schedule / slots
+DELETE FROM teacher_available_slots;
+DELETE FROM teacher_work_schedules;
+
+-- L4: contract addendums (polymorphic FK，無 CASCADE，需要在 contracts 前刪)
+DELETE FROM contract_addendums;
+
+-- L5: contracts (details / leave_records on contract CASCADE)
+DELETE FROM teacher_contracts;
+DELETE FROM student_contracts;
+
+-- L6: student 其他關聯
+DELETE FROM student_courses;
+DELETE FROM student_teacher_preferences;
+
+-- L7: notification / alert log
+DELETE FROM notification_logs;
+DELETE FROM line_notification_logs;
+DELETE FROM notification_queue;
+DELETE FROM system_alerts;
+
+COMMIT;
+SQL
+
+# ─── 4. 驗證後狀態 ───
+echo
+echo "==> 執行後狀態"
+psql -At <<'SQL' | column -t -s '|'
+SELECT 'bookings',                count(*) FROM bookings
+UNION ALL SELECT 'teacher_contracts',       count(*) FROM teacher_contracts
+UNION ALL SELECT 'student_contracts',       count(*) FROM student_contracts
+UNION ALL SELECT 'leave_records',           count(*) FROM leave_records
+UNION ALL SELECT 'teacher_available_slots', count(*) FROM teacher_available_slots
+UNION ALL SELECT '— 保留 —',                 NULL::bigint
+UNION ALL SELECT 'users (kept)',            count(*) FROM users
+UNION ALL SELECT 'teachers (kept)',         count(*) FROM teachers
+UNION ALL SELECT 'students (kept)',         count(*) FROM students
+UNION ALL SELECT 'employees (kept)',        count(*) FROM employees
+UNION ALL SELECT 'roles (kept)',            count(*) FROM roles
+UNION ALL SELECT 'courses (kept)',          count(*) FROM courses
+ORDER BY 1;
+SQL
+
+echo
+echo "✓ 完成"

--- a/supabase/migrations/057_course_duration_check.sql
+++ b/supabase/migrations/057_course_duration_check.sql
@@ -1,0 +1,5 @@
+-- 057: courses.duration_minutes 限制為 30 或 60（業務上只有這兩種）
+-- 線上資料只有 30 / 60，加 CHECK 不會違反既有 row。
+ALTER TABLE courses
+    ADD CONSTRAINT chk_courses_duration_minutes
+    CHECK (duration_minutes IN (30, 60));


### PR DESCRIPTION
> 多個小型 PR 合併成一支進 dev，commit 各帶 issue ref，方便逐筆審。

## 包含的變更

| Commit | 主題 | 相關 |
|---|---|---|
| `a18ba93` | feat(bookings): 新增 POST /bookings/{id}/cancel-pending — 取消待確認預約 | #68 |
| `5acf07d` | docs(bookings): cancel-pending 加 OpenAPI summary + response model + path param example | #68 |
| `4e52f61` | chore(scripts): 新增 db-purge-business-data.sh — 清業務資料但保留所有帳號 | — |
| `199a4d6` | feat(bookings/demo): 串接 cancel-pending 端點，pending 預約加「取消」按鈕 | #68 |
| `773e8c0` | feat(leave-records): 員工代申請須指定 initiator_type（student/teacher） | Closes #70 |
| `274bbe7` | feat(bookings/demo): 員工請假 Modal 加「代申請對象」radio | #70 |
| `42aac5e` | feat(courses): duration_minutes 限制為 enum 30 / 60 | Closes #33 |

## 1. Cancel pending booking — #68

### Backend (a18ba93, 5acf07d)
新增 `POST /api/v1/bookings/{booking_id}/cancel-pending`：
- 員工：可取消任何 pending booking
- 老師 / 學生：只能取消自己的 pending booking（handler 內 inline check）
- 行為：`booking_status: pending → cancelled` + `cancel_booking_side_effects()`（堂數退回 + slot 釋放 + Zoom 取消 silent skip）
- 設計切割：pending 走 cancel（不需審核），confirmed 走請假（需審核 + 計入合約 leave count）

### Frontend (199a4d6)
- `bookingsApi.cancelPending(id)` API client
- 員工 / 老師 / 學生三個角色路徑的 pending booking 都顯示「取消」按鈕
- 新 confirm modal（不收 reason，配合新端點 signature）

## 2. 員工代申請 initiator_type — Closes #70

### Backend (773e8c0)
- `LeaveRecordCreate` 加 `initiator_type: Optional[Literal['student','teacher']]`
- `create_leave_record` 重構：initiator_type 判斷移到緊急請假額度檢查之前
  - 員工呼叫必填；學生 / 老師忽略此欄位由角色推斷
  - 額度檢查改用 `initiator_type=='teacher'` 豁免，取代 `current_user.is_teacher()`
  - 員工代老師申請也走相同豁免路徑（不消耗學生額度、不寫 `student_contract_leave_records`）
- 嚴格綁 booking：`initiator_teacher_id` / `initiator_student_id` 從 booking 取，不允許自由指定

### Frontend (274bbe7)
- `LeaveModal` 接 `isStaff` prop；員工才顯示「幫學生 / 幫老師」radio，必選
- 學生 / 老師路徑不送 `initiator_type`

## 3. course duration enum — Closes #33

### Schema (42aac5e)
- `duration_minutes` 從 `int(15-480)` 改為 `Literal[30, 60]`，invalid 422 with literal_error
- migration 057：加 DB `CHECK (duration_minutes IN (30, 60))` defense-in-depth
- 前端 courses 頁：課程時長 input 從 number 改 select 30/60

## 4. db-purge-business-data 腳本 (4e52f61)

新增 `scripts/db-purge-business-data.sh`：清業務資料（合約、預約、請假、代課、獎金等）但保留所有 user 帳號 + roles + permissions + courses。

對應既有 `db-purge-students-teachers.sh` 的更窄版本（不刪 teacher/student 本體）。

跟既有腳本共用安全閘：CONTAINER 名稱必須是本機、互動確認、`--dry-run`、`--yes`、單一 transaction 失敗 rollback。

---

## 驗證

| Suite | 結果 |
|---|---|
| `live_e2e_leave_flow_test.py` | 14/14 ✓（含新增 3 個 case：員工沒帶 initiator_type → 400、員工代老師申請 200、核准不消耗學生額度）|
| `live_e2e_courses_test.py` | 17/17 ✓（含新增 2 個 case：90 → 422、30 → 200）|
| `live_e2e_booking_flow_test.py` | 38/38 ✓（regression）|

## 不在範圍

- batch cancel pending（先做單筆）
- Vue 舊前端的 cancel-pending UI（不維護）
- e2e 為 cancel-pending 端點補完整 happy path / 403 / 400 case